### PR TITLE
[강우진] sprint2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ bin/
 .idea
 ...
 /src/main/generated/
+*.ser

--- a/src/main/java/com/sprint/mission/discodeit/JavaApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/JavaApplication.java
@@ -3,8 +3,20 @@ package com.sprint.mission.discodeit;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.Message;
 import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.repository.file.FileChannelRepository;
+import com.sprint.mission.discodeit.repository.file.FileMessageRepository;
+import com.sprint.mission.discodeit.repository.file.FileUserRepository;
+import com.sprint.mission.discodeit.repository.jcf.JcfChannelRepository;
+import com.sprint.mission.discodeit.repository.jcf.JcfMessageRepository;
+import com.sprint.mission.discodeit.repository.jcf.JcfUserRepository;
 import com.sprint.mission.discodeit.service.ChannelService;
 import com.sprint.mission.discodeit.service.UserService;
+import com.sprint.mission.discodeit.service.basic.BasicChannelService;
+import com.sprint.mission.discodeit.service.basic.BasicMessageService;
+import com.sprint.mission.discodeit.service.basic.BasicUserService;
 import com.sprint.mission.discodeit.service.factory.ServiceFactory;
 import com.sprint.mission.discodeit.service.file.FileMessageService;
 import com.sprint.mission.discodeit.service.jcf.JcfMessageService;
@@ -16,14 +28,31 @@ import java.util.UUID;
 
 public class JavaApplication {
   public static void main(String[] args) {
-    //JcfUserServiceUsingMap userService = new JcfUserServiceUsingMap();
+    // JCF*Repository  구현체를 활용하여 테스트
+//    UserRepository userRepo = new JcfUserRepository();
+//    ChannelRepository channelRepo = new JcfChannelRepository();
+//    MessageRepository messageRepo = new JcfMessageRepository();
 
-    ServiceFactory.initializeServices();
-    UserService userService = ServiceFactory.getUserService();
-    ChannelService channelService = ServiceFactory.getChannelService();
+    // File*Repository 구현체를 활용하여 테스트
+    UserRepository userRepo = new FileUserRepository();
+    ChannelRepository channelRepo = new FileChannelRepository();
+    MessageRepository messageRepo = new FileMessageRepository();
+
+    // Service 구현체 생성
+    BasicUserService userService = new BasicUserService(userRepo);
+    BasicChannelService channelService = new BasicChannelService(channelRepo, userService);
+    BasicMessageService messageService = new BasicMessageService(messageRepo, userService, channelService);
+
+    // 순환 참조 setter 주입
+    userService.setChannelService(channelService);
+
+    // sprint1 mission - 팩토리메서드
+//    ServiceFactory.initializeServices();
+//    UserService userService = ServiceFactory.getUserService();
+//    ChannelService channelService = ServiceFactory.getChannelService();
 
     //JcfMessageService messageService = new JcfMessageService(userService, channelService);
-    FileMessageService messageService = new FileMessageService(userService, channelService);
+    //FileMessageService messageService = new FileMessageService(userService, channelService);
 
     //  유저 생성
     User test01 = userService.createUser("test01", "test01@.com");

--- a/src/main/java/com/sprint/mission/discodeit/JavaApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/JavaApplication.java
@@ -6,6 +6,7 @@ import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.service.ChannelService;
 import com.sprint.mission.discodeit.service.UserService;
 import com.sprint.mission.discodeit.service.factory.ServiceFactory;
+import com.sprint.mission.discodeit.service.file.FileMessageService;
 import com.sprint.mission.discodeit.service.jcf.JcfMessageService;
 
 import java.util.HashMap;
@@ -21,11 +22,8 @@ public class JavaApplication {
     UserService userService = ServiceFactory.getUserService();
     ChannelService channelService = ServiceFactory.getChannelService();
 
-//    JcfUserService userService = new JcfUserService();
-//    JcfChannelService channelService = new JcfChannelService(userService);
-//    userService.setChannelService(channelService);
-
-    JcfMessageService messageService = new JcfMessageService(userService, channelService);
+    //JcfMessageService messageService = new JcfMessageService(userService, channelService);
+    FileMessageService messageService = new FileMessageService(userService, channelService);
 
     //  유저 생성
     User test01 = userService.createUser("test01", "test01@.com");

--- a/src/main/java/com/sprint/mission/discodeit/JavaApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/JavaApplication.java
@@ -6,9 +6,7 @@ import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.service.ChannelService;
 import com.sprint.mission.discodeit.service.UserService;
 import com.sprint.mission.discodeit.service.factory.ServiceFactory;
-import com.sprint.mission.discodeit.service.jcf.JcfChannelService;
 import com.sprint.mission.discodeit.service.jcf.JcfMessageService;
-import com.sprint.mission.discodeit.service.jcf.JcfUserService;
 
 import java.util.HashMap;
 import java.util.List;
@@ -35,20 +33,20 @@ public class JavaApplication {
     User test03 = userService.createUser("test03", "test03@.com");
     User test04 = userService.createUser("test04", "test04@.com");
 
-    //개별 유저 조회
-    User testuser01 = userService.getUserById(test01.getId());
-    System.out.println("===개별 User 조회 ===" + "\n" + testuser01);
+    userService.getUserById(test01.getId()).ifPresentOrElse(user -> {
+      System.out.println("===개별 User 조회 ===\n" + user);
 
-    //전체 유저 조회
+      System.out.println("\n=== test01 이름변경 후 조회 ===");
+      userService.updateUserName(user.getId(), "test0101");
+      System.out.println(userService.getUserById(user.getId()).orElse(null));
+    }, () -> {
+      System.out.println("test01 유저를 찾을 수 없습니다.");
+    });
+
     System.out.println("\n=== 전체 유저 조회 ===");
     userService.getAllUsers().forEach(System.out::println);
 
-    //유저 정보 수정 테스트
-    System.out.println("\n=== test01 이름변경 후 조회===");
-    userService.updateUserName(testuser01.getId(), "test0101");
-    System.out.println(userService.getUserById(testuser01.getId()));
-
-    //유저 삭제 후 전체 유저 조회 //  try-catch로 만약 유저가 존재하지 않으면 예외 처리 필요
+// test02 삭제 및 조회
     userService.deleteUser(test02.getId());
     System.out.println("\n=== test02 삭제 후 전체 조회 ===");
     userService.getAllUsers().forEach(System.out::println);
@@ -61,9 +59,11 @@ public class JavaApplication {
     Channel channel2 = channelService.createChannel("2024_Channel", test02);
 
     // 개별 채널 조회
-    Channel testChannel = channelService.getChannelById(channel2.getId());
     System.out.println("\n=== 개별 채널 조회 ===");
-    System.out.println(testChannel);
+    channelService.getChannelById(channel2.getId()).ifPresentOrElse(
+        channel -> System.out.println(channel),
+        () -> System.out.println("해당 채널이 존재하지 않습니다.")
+    );
 
     System.out.println("\n=== 채널 이름(2024_Channel) 수정 후 전체 채널 조회 ===");
     channelService.updateChannelName(channel2.getId(), "2023_channel");
@@ -77,7 +77,11 @@ public class JavaApplication {
 
     // 유저 추가 (test02, test03을 채널에 추가)  & 삭제된 유저는 data에 담을 수 없다.
     System.out.println("\n=== 2025_Channel에 멤버(test02(탈퇴),test03) 추가 ===");
-    channelService.addMember(channel1.getId(), test02.getId()); // test02는 삭제된 유저
+    try {
+      channelService.addMember(channel1.getId(), test02.getId()); // test02는 삭제된 유저
+    } catch (IllegalArgumentException e) {
+      System.out.println("예외 발생: " + e.getMessage());
+    }
     channelService.addMember(channel1.getId(), test03.getId());
 
     // 채널 멤버 조회
@@ -171,18 +175,21 @@ public class JavaApplication {
 
     if (!messages.isEmpty()) {
       UUID messageId = messages.get(0).getId(); // 첫 번째 메시지를 대상으로 수정
-      Message originalMessage = messageService.getMessageById(messageId); // 수정 전 메시지
 
-      if (originalMessage != null) {
+      // 수정 전 메시지 조회
+      messageService.getMessageById(messageId).ifPresent(originalMessage -> {
         String oldContent = originalMessage.getContent(); // 수정 전 내용
 
+        // 메시지 수정
         messageService.updateMessage(messageId, user1.getId(), "안녕하세요 저는 user1입니다. 이름은 john입니다. (수정)");
-        Message updatedMessage = messageService.getMessageById(messageId); // 수정 후 메시지
 
-        System.out.println("메시지 수정 완료");
-        System.out.println("수정 전: \"" + oldContent + "\"");
-        System.out.println("수정 후: \"" + updatedMessage.getContent() + "\"");
-      }
+        // 수정 후 메시지 조회
+        messageService.getMessageById(messageId).ifPresent(updatedMessage -> {
+          System.out.println("메시지 수정 완료");
+          System.out.println("수정 전: \"" + oldContent + "\"");
+          System.out.println("수정 후: \"" + updatedMessage.getContent() + "\"");
+        });
+      });
     } else {
       System.out.println("수정할 메시지가 없습니다.");
     }

--- a/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
@@ -2,11 +2,14 @@ package com.sprint.mission.discodeit.entity;
 
 import lombok.Getter;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.UUID;
 
 @Getter
-public class Channel {
+public class Channel implements Serializable {
+  private static final long serialVersionUID = 1L;
+
   private final UUID id;
   private final Long createdAt;
   private Long updatedAt;

--- a/src/main/java/com/sprint/mission/discodeit/entity/Message.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Message.java
@@ -1,10 +1,14 @@
 package com.sprint.mission.discodeit.entity;
 
 import lombok.Getter;
+
+import java.io.Serializable;
 import java.util.UUID;
 
 @Getter
-public class Message {
+public class Message implements Serializable {
+  private static final long serialVersionUID = 1L;
+
   private final UUID id;
   private final Long createdAt;
   private Long updatedAt;

--- a/src/main/java/com/sprint/mission/discodeit/entity/User.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/User.java
@@ -1,5 +1,6 @@
 package com.sprint.mission.discodeit.entity;
 
+import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -8,7 +9,9 @@ import java.util.UUID;
 import lombok.Getter;
 
 @Getter
-public class User {
+public class User implements Serializable {
+  private static final long serialVersionUID = 1L;
+
   private final UUID id;
   private final Long createdAt;
   private Long updatedAt;

--- a/src/main/java/com/sprint/mission/discodeit/repository/ChannelRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/ChannelRepository.java
@@ -1,0 +1,30 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.Channel;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ChannelRepository {
+  // 1. 채널 생성
+  Channel save(Channel channel);
+
+  // 2. 채널 단건 조회
+  Optional<Channel> getChannelById(UUID channelId);
+
+  // 3. 채널 전체 조회
+  List<Channel> getAllChannels();
+
+  // 4. 채널 이름 수정
+  void update(Channel channel);
+
+  // 5. 채널 삭제
+  void delete(UUID channelId);
+
+  // 6. 유저가 만든 채널 삭제
+  void deleteByOwnerId(UUID userId);
+
+  // 7. 유저가 참여 중인 모든 채널에서 삭제
+  void removeUserFromAllChannels(UUID userId);
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
@@ -1,0 +1,30 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.Message;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MessageRepository {
+  // 메시지 저장
+  Message save(Message message);
+
+  // 메시지 ID로 메시지를 조회
+  Optional<Message> findById(UUID messageId);
+
+  // 메시지를 삭제
+  void delete(UUID messageId);
+
+  // 특정 채널에 속한 모든 메시지를 조회
+  List<Message> findByChannelId(UUID channelId);
+
+  // 특정 유저가 보낸 모든 메시지를 조회
+  List<Message> findBySenderId(UUID senderId);
+
+  // 특정 채널에서 메시지를 제거
+  void removeFromChannel(UUID channelId, Message message);
+
+  // 특정 유저의 메시지 목록에서 메시지를 제거
+  void removeFromUser(UUID userId, Message message);
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/UserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/UserRepository.java
@@ -1,0 +1,25 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository {
+  // 유저 생성
+  void save(User user);
+
+  // 유저 단건 조회 (ID로)
+  Optional<User> getUserById(UUID id);
+
+  // 모든 유저 조회
+  List<User> getAllUsers();
+
+  // 유저 수정
+  void update(User user);
+
+  // 유저 삭제
+  void delete(UUID id);
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileChannelRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileChannelRepository.java
@@ -1,0 +1,106 @@
+package com.sprint.mission.discodeit.repository.file;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+
+import java.io.*;
+import java.util.*;
+
+public class FileChannelRepository implements ChannelRepository {
+  private static final String FILE_PATH = "channels.ser";
+  private final Map<UUID, Channel> channelData;
+
+  public FileChannelRepository() {
+    this.channelData = loadChannelData();
+  }
+
+  // 직렬화된 파일에서 채널 데이터를 불러옴
+  private Map<UUID, Channel> loadChannelData() {
+    File file = new File(FILE_PATH);
+    if (!file.exists()) {
+      return new HashMap<>();
+    }
+    try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
+      return (Map<UUID, Channel>) ois.readObject();
+    } catch (IOException | ClassNotFoundException e) {
+      e.printStackTrace();
+      return new HashMap<>();
+    }
+  }
+
+  // 채널 데이터를 파일로 저장
+  private void saveChannelData() {
+    try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(FILE_PATH))) {
+      oos.writeObject(channelData);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  // 1. 채널 생성
+  @Override
+  public Channel save(Channel channel) {
+    channelData.put(channel.getId(), channel);
+    saveChannelData();
+    return channel;
+  }
+
+  // 2. 채널 단건 조회
+  @Override
+  public Optional<Channel> getChannelById(UUID channelId) {
+    return Optional.ofNullable(channelData.get(channelId));
+  }
+
+  // 3. 채널 전체 조회
+  @Override
+  public List<Channel> getAllChannels() {
+    return new ArrayList<>(channelData.values());
+  }
+
+  // 4. 채널 수정 (채널 이름 등 변경사항 반영)
+  @Override
+  public void update(Channel channel) {
+    if (!channelData.containsKey(channel.getId())) {
+      throw new IllegalArgumentException("해당 채널이 존재하지 않습니다: " + channel.getId());
+    }
+    channelData.put(channel.getId(), channel); // 기존 채널 덮어쓰기
+    saveChannelData();
+  }
+
+  // 5. 채널 삭제
+  @Override
+  public void delete(UUID channelId) {
+    channelData.remove(channelId);
+    saveChannelData();
+  }
+
+  // 6. 유저가 만든 채널 전체 삭제
+  @Override
+  public void deleteByOwnerId(UUID userId) {
+    channelData.entrySet().removeIf(entry -> entry.getValue().getChannelOwner().getId().equals(userId));
+    saveChannelData();
+  }
+
+  // 7. 유저가 참여 중인 모든 채널에서 유저 제거
+  @Override
+  public void removeUserFromAllChannels(UUID userId) {
+    for (Channel channel : channelData.values()) {
+      channel.getChannelUsers().removeIf(user -> user.getId().equals(userId));
+    }
+    saveChannelData();
+  }
+
+  /*
+ Repository: 데이터를 영속화(storage)하는 계층
+데이터를 단순히 저장/조회/삭제/갱신
+getChannelById, save, delete, update 같은 CRUD 담당
+로직 판단, 유효성 검사, 상태 변경 등 비즈니스 로직은 수행하지 않음
+
+ Service: 비즈니스 로직을 수행하는 계층
+도메인 간의 관계 처리, 검증, 상태 변화 등 핵심 로직을 수행
+-채널 이름 중복 검사
+-채널에 참여자 추가/삭제
+-특정 조건 충족 시 예외 던지기
+-도메인 간 연계 (예: 유저가 삭제되면 채널에서 제거)
+   */
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
@@ -1,0 +1,88 @@
+package com.sprint.mission.discodeit.repository.file;
+
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+
+import java.io.*;
+import java.util.*;
+
+public class FileMessageRepository implements MessageRepository {
+  private static final String FILE_PATH = "messages.ser";
+
+  private Map<UUID, Message> messageMap = new HashMap<>();
+  private Map<UUID, List<Message>> channelMessagesMap = new HashMap<>();
+  private Map<UUID, List<Message>> userMessagesMap = new HashMap<>();
+
+  public FileMessageRepository() {
+    loadData();
+  }
+
+  private void loadData() {
+    File file = new File(FILE_PATH);
+    if (!file.exists()) return;
+
+    try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
+      messageMap = (Map<UUID, Message>) ois.readObject();
+      channelMessagesMap = (Map<UUID, List<Message>>) ois.readObject();
+      userMessagesMap = (Map<UUID, List<Message>>) ois.readObject();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void saveData() {
+    try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(FILE_PATH))) {
+      oos.writeObject(messageMap);
+      oos.writeObject(channelMessagesMap);
+      oos.writeObject(userMessagesMap);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public Message save(Message message) {
+    messageMap.put(message.getId(), message);
+    channelMessagesMap.computeIfAbsent(message.getChannelId(), k -> new ArrayList<>()).add(message);
+    userMessagesMap.computeIfAbsent(message.getSenderId(), k -> new ArrayList<>()).add(message);
+    saveData();
+    return message;
+  }
+
+  @Override
+  public Optional<Message> findById(UUID messageId) {
+    return Optional.ofNullable(messageMap.get(messageId));
+  }
+
+  @Override
+  public void delete(UUID messageId) {
+    Message msg = messageMap.remove(messageId);
+    if (msg != null) {
+      channelMessagesMap.getOrDefault(msg.getChannelId(), new ArrayList<>()).remove(msg);
+      userMessagesMap.getOrDefault(msg.getSenderId(), new ArrayList<>()).remove(msg);
+      saveData();
+    }
+  }
+
+  @Override
+  public List<Message> findByChannelId(UUID channelId) {
+    return new ArrayList<>(channelMessagesMap.getOrDefault(channelId, Collections.emptyList()));
+  }
+
+  @Override
+  public List<Message> findBySenderId(UUID senderId) {
+    return new ArrayList<>(userMessagesMap.getOrDefault(senderId, Collections.emptyList()));
+  }
+
+  @Override
+  public void removeFromChannel(UUID channelId, Message message) {
+    channelMessagesMap.getOrDefault(channelId, new ArrayList<>()).remove(message);
+    saveData();
+  }
+
+  @Override
+  public void removeFromUser(UUID userId, Message message) {
+    userMessagesMap.getOrDefault(userId, new ArrayList<>()).remove(message);
+    saveData();
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserRepository.java
@@ -1,0 +1,75 @@
+package com.sprint.mission.discodeit.repository.file;
+
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.UserRepository;
+
+import java.io.*;
+import java.util.*;
+
+public class FileUserRepository implements UserRepository {
+  private static final String FILE_PATH = "users.ser";
+  private final Map<UUID, User> userData;
+
+  public FileUserRepository() {
+    this.userData = loadUserData();
+  }
+
+  // 파일로부터 유저 데이터 로드
+  private Map<UUID, User> loadUserData() {
+    File file = new File(FILE_PATH);
+    if (!file.exists()) {
+      return new HashMap<>();
+    }
+    try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
+      return (Map<UUID, User>) ois.readObject();
+    } catch (IOException | ClassNotFoundException e) {
+      e.printStackTrace();
+      return new HashMap<>();
+    }
+  }
+
+  // 유저 데이터를 파일로 저장
+  private void saveUserData() {
+    try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(FILE_PATH))) {
+      oos.writeObject(userData);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  // 유저 저장 (create)
+  @Override
+  public void save(User user) {
+    userData.put(user.getId(), user);
+    saveUserData();
+  }
+
+  // 유저 단건 조회
+  @Override
+  public Optional<User> getUserById(UUID id) {
+    return Optional.ofNullable(userData.get(id));
+  }
+
+  // 모든 유저 조회
+  @Override
+  public List<User> getAllUsers() {
+    return new ArrayList<>(userData.values());
+  }
+
+  // 유저 수정
+  @Override
+  public void update(User user) {
+    if (!userData.containsKey(user.getId())) {
+      throw new IllegalArgumentException("해당 ID의 유저가 존재하지 않습니다: " + user.getId());
+    }
+    userData.put(user.getId(), user); // 업데이트는 덮어쓰기
+    saveUserData();
+  }
+
+  // 유저 삭제
+  @Override
+  public void delete(UUID id) {
+    userData.remove(id);
+    saveUserData();
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/jcf/JcfChannelRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/jcf/JcfChannelRepository.java
@@ -1,0 +1,54 @@
+package com.sprint.mission.discodeit.repository.jcf;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+
+import java.util.*;
+
+public class JcfChannelRepository implements ChannelRepository {
+  private final Map<UUID, Channel> channelMap = new HashMap<>();
+
+  @Override
+  public Channel save(Channel channel) {
+    channelMap.put(channel.getId(), channel);
+    return channel;
+  }
+
+  @Override
+  public Optional<Channel> getChannelById(UUID channelId) {
+    return Optional.ofNullable(channelMap.get(channelId));
+  }
+
+  @Override
+  public List<Channel> getAllChannels() {
+    return new ArrayList<>(channelMap.values());
+  }
+
+  @Override
+  public void update(Channel channel) {
+    if (!channelMap.containsKey(channel.getId())) {
+      throw new IllegalArgumentException("채널을 찾을 수 없습니다: " + channel.getId());
+    }
+    channelMap.put(channel.getId(), channel);  // 이미 존재하는 채널을 덮어씌운다
+  }
+
+  @Override
+  public void delete(UUID channelId) {
+    if (!channelMap.containsKey(channelId)) {
+      throw new IllegalArgumentException("채널을 찾을 수 없습니다: " + channelId);
+    }
+    channelMap.remove(channelId);
+  }
+
+  @Override
+  public void deleteByOwnerId(UUID userId) {
+    channelMap.values().removeIf(channel -> channel.getChannelOwner().getId().equals(userId));
+  }
+
+  @Override
+  public void removeUserFromAllChannels(UUID userId) {
+    for (Channel channel : channelMap.values()) {
+      channel.getChannelUsers().removeIf(user -> user.getId().equals(userId));
+    }
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/jcf/JcfMessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/jcf/JcfMessageRepository.java
@@ -1,0 +1,55 @@
+package com.sprint.mission.discodeit.repository.jcf;
+
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+
+import java.util.*;
+
+public class JcfMessageRepository implements MessageRepository {
+
+  private final Map<UUID, Message> messageMap = new HashMap<>();
+  private final Map<UUID, List<Message>> channelMessagesMap = new HashMap<>();
+  private final Map<UUID, List<Message>> userMessagesMap = new HashMap<>();
+
+  @Override
+  public Message save(Message message) {
+    messageMap.put(message.getId(), message);
+    channelMessagesMap.computeIfAbsent(message.getChannelId(), k -> new ArrayList<>()).add(message);
+    userMessagesMap.computeIfAbsent(message.getSenderId(), k -> new ArrayList<>()).add(message);
+    return message;
+  }
+
+  @Override
+  public Optional<Message> findById(UUID messageId) {
+    return Optional.ofNullable(messageMap.get(messageId));
+  }
+
+  @Override
+  public void delete(UUID messageId) {
+    Message msg = messageMap.remove(messageId);
+    if (msg != null) {
+      removeFromChannel(msg.getChannelId(), msg);
+      removeFromUser(msg.getSenderId(), msg);
+    }
+  }
+
+  @Override
+  public List<Message> findByChannelId(UUID channelId) {
+    return channelMessagesMap.getOrDefault(channelId, Collections.emptyList());
+  }
+
+  @Override
+  public List<Message> findBySenderId(UUID senderId) {
+    return userMessagesMap.getOrDefault(senderId, Collections.emptyList());
+  }
+
+  @Override
+  public void removeFromChannel(UUID channelId, Message message) {
+    channelMessagesMap.getOrDefault(channelId, new ArrayList<>()).remove(message);
+  }
+
+  @Override
+  public void removeFromUser(UUID userId, Message message) {
+    userMessagesMap.getOrDefault(userId, new ArrayList<>()).remove(message);
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/jcf/JcfUserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/jcf/JcfUserRepository.java
@@ -1,0 +1,55 @@
+package com.sprint.mission.discodeit.repository.jcf;
+
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.UserRepository;
+
+import java.util.*;
+
+public class JcfUserRepository implements UserRepository {
+  private final Map<UUID, User> userMap;
+
+  public JcfUserRepository() {
+    this.userMap = new HashMap<>();
+  }
+
+  @Override
+  public void save(User user) {
+    userMap.put(user.getId(), user);
+  }
+
+  @Override
+  public Optional<User> getUserById(UUID id) {
+    return Optional.ofNullable(userMap.get(id));
+  }
+
+  @Override
+  public List<User> getAllUsers() {
+    return new ArrayList<>(userMap.values());
+  }
+
+  @Override
+  public void update(User user) {
+    if (!userMap.containsKey(user.getId())) {
+      throw new IllegalArgumentException("해당 ID의 유저가 존재하지 않습니다: " + user.getId());
+    }
+    userMap.put(user.getId(), user);
+  }
+
+  @Override
+  public void delete(UUID id) {
+    if (!userMap.containsKey(id)) {
+      throw new IllegalArgumentException("해당 ID의 유저가 존재하지 않습니다: " + id);
+    }
+    userMap.remove(id);
+  }
+
+  /*
+ JcfUserRepository는 Map<UUID, User>를 사용하여 데이터를 관리하고, CRUD 기능을 수행함.
+JcfUserService는 UserRepository를 주입받아 유저 데이터를 관리하고, 유저 생성, 수정, 삭제 등 비즈니스 로직을 담당함.
+
+createUser(), updateUserName(), updateUserEmail(), deleteUser() 등 서비스 로직에서 데이터를 수정한 후,
+JcfUserRepository의 update(), save(), delete() 메서드를 호출해 데이터 저장소에 반영함.
+
+JcfUserService는 비즈니스 로직만 처리하고, 데이터 저장 및 조회는 JcfUserRepository가 담당한다.
+   */
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
@@ -4,6 +4,7 @@ import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.User;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ChannelService {
@@ -13,7 +14,7 @@ public interface ChannelService {
   Channel createChannel(String channelName, User ownerUser);
 
   // 2. 단일 채널 조회
-  Channel getChannelById(UUID channelId);
+  Optional<Channel> getChannelById(UUID channelId);
 
   // 3. 전체 채널 조회
   List<Channel> getAllChannels();

--- a/src/main/java/com/sprint/mission/discodeit/service/UserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/UserService.java
@@ -3,13 +3,14 @@ package com.sprint.mission.discodeit.service;
 import com.sprint.mission.discodeit.entity.User;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserService {
   // 1. 유저 생성
   User createUser(String username, String email);
   // 2. 유저 단건 조회
-  User getUserById(UUID id);
+  Optional<User> getUserById(UUID id);
   // 3. 유저 전체 조회
   List<User> getAllUsers();
   // 4. 유저 수정

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -1,0 +1,116 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.service.UserService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class BasicChannelService implements ChannelService {
+
+  private final ChannelRepository channelRepository;
+  private final UserService userService;
+
+  public BasicChannelService(ChannelRepository channelRepository, UserService userService) {
+    this.channelRepository = channelRepository;
+    this.userService = userService;
+  }
+
+  @Override
+  public Channel createChannel(String channelName, User ownerUser) {
+    boolean isDuplicate = channelRepository.getAllChannels().stream()
+        .anyMatch(c -> c.getChannelOwner().getId().equals(ownerUser.getId())
+            && c.getChannelName().equals(channelName));
+
+    if (isDuplicate) {
+      throw new IllegalArgumentException("이미 같은 이름의 채널이 존재합니다.");
+    }
+
+    List<User> members = new ArrayList<>();
+    members.add(ownerUser);
+
+    Channel channel = new Channel(channelName, ownerUser, members);
+    return channelRepository.save(channel);
+  }
+
+  @Override
+  public Optional<Channel> getChannelById(UUID channelId) {
+    return channelRepository.getChannelById(channelId);
+  }
+
+  @Override
+  public List<Channel> getAllChannels() {
+    return channelRepository.getAllChannels();
+  }
+
+  @Override
+  public void updateChannelName(UUID channelId, String newChannelName) {
+    Channel channel = channelRepository.getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채널입니다."));
+
+    if (channel.getChannelName().equals(newChannelName)) {
+      throw new IllegalArgumentException("채널 이름이 기존과 동일합니다.");
+    }
+
+    UUID ownerId = channel.getChannelOwner().getId();
+    boolean isDuplicate = channelRepository.getAllChannels().stream()
+        .anyMatch(c -> c.getChannelOwner().getId().equals(ownerId)
+            && c.getChannelName().equals(newChannelName));
+
+    if (isDuplicate) {
+      throw new IllegalArgumentException("이미 해당 채널명이 존재합니다.");
+    }
+
+    channel.updateChannelName(newChannelName);
+    channelRepository.update(channel);
+  }
+
+  @Override
+  public void deleteChannel(UUID channelId) {
+    channelRepository.delete(channelId);
+  }
+
+  @Override
+  public void addMember(UUID channelId, UUID userId) {
+    Channel channel = channelRepository.getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채널 ID입니다."));
+    User user = userService.getUserById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 ID입니다."));
+
+    channel.addChannelUser(user);
+    channelRepository.update(channel);
+  }
+
+  @Override
+  public void removeMember(UUID channelId, UUID userId) {
+    Channel channel = channelRepository.getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채널 ID입니다."));
+    User user = userService.getUserById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 ID입니다."));
+
+    channel.removeChannelUser(user);
+    channelRepository.update(channel);
+  }
+
+  @Override
+  public List<User> getChannelMembers(UUID channelId) {
+    Channel channel = channelRepository.getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채널 ID입니다."));
+    return new ArrayList<>(channel.getChannelUsers());
+  }
+
+  @Override
+  public void deleteChannelsCreatedByUser(UUID userId) {
+    channelRepository.deleteByOwnerId(userId);
+  }
+
+  @Override
+  public void removeUserFromAllChannels(UUID userId) {
+    channelRepository.removeUserFromAllChannels(userId);
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
@@ -1,0 +1,152 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.service.MessageService;
+import com.sprint.mission.discodeit.service.UserService;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+public class BasicMessageService implements MessageService {
+  private final MessageRepository messageRepository;
+  private final UserService userService;
+  private final ChannelService channelService;
+
+  private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("MM월 dd일 a hh시 mm분 ss초");
+
+  public BasicMessageService(MessageRepository messageRepository, UserService userService, ChannelService channelService) {
+    this.messageRepository = messageRepository;
+    this.userService = userService;
+    this.channelService = channelService;
+  }
+
+  @Override
+  public Message createMessage(UUID channelId, UUID senderId, String content) {
+    Channel channel = channelService.getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 채널이 존재하지 않습니다."));
+    User sender = userService.getUserById(senderId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+    if (channel.getChannelUsers().size() < 2) {
+      throw new IllegalStateException("채널에 최소 두 명 이상의 유저가 있어야 메시지를 보낼 수 있습니다.");
+    }
+
+    if (!channel.getChannelUsers().contains(sender)) {
+      throw new IllegalArgumentException("해당 유저는 이 채널의 멤버가 아닙니다.");
+    }
+
+    Message message = new Message(content, channelId, senderId);
+    return messageRepository.save(message);
+  }
+
+  @Override
+  public List<Message> getMessagesBySenderInChannel(UUID channelId, UUID senderId) {
+    Channel channel = channelService.getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("채널이 존재하지 않습니다."));
+    if (channel.getChannelUsers().stream().noneMatch(u -> u.getId().equals(senderId))) {
+      throw new IllegalArgumentException("해당 유저는 이 채널의 멤버가 아닙니다.");
+    }
+
+    return messageRepository.findByChannelId(channelId).stream()
+        .filter(m -> m.getSenderId().equals(senderId))
+        .toList();
+  }
+
+  @Override
+  public List<Message> getMessagesByReceiverInChannel(UUID channelId, UUID receiverId) {
+    Channel channel = channelService.getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("채널이 존재하지 않습니다."));
+    if (channel.getChannelUsers().stream().noneMatch(u -> u.getId().equals(receiverId))) {
+      throw new IllegalArgumentException("해당 유저는 이 채널의 멤버가 아닙니다.");
+    }
+
+    return messageRepository.findByChannelId(channelId).stream()
+        .filter(m -> !m.getSenderId().equals(receiverId))
+        .toList();
+  }
+
+  @Override
+  public List<Message> getAllSentMessages(UUID senderId) {
+    return messageRepository.findBySenderId(senderId);
+  }
+
+  @Override
+  public List<Message> getAllReceivedMessages(UUID receiverId) {
+    List<UUID> myChannels = channelService.getAllChannels().stream()
+        .filter(ch -> ch.getChannelUsers().stream().anyMatch(u -> u.getId().equals(receiverId)))
+        .map(Channel::getId)
+        .toList();
+
+    List<Message> received = new ArrayList<>();
+    for (UUID chId : myChannels) {
+      List<Message> messages = messageRepository.findByChannelId(chId);
+      for (Message msg : messages) {
+        if (!msg.getSenderId().equals(receiverId)) {
+          received.add(msg);
+        }
+      }
+    }
+    return received;
+  }
+
+  @Override
+  public void updateMessage(UUID messageId, UUID senderId, String newContent) {
+    Message msg = messageRepository.findById(messageId)
+        .orElseThrow(() -> new IllegalArgumentException("메시지를 찾을 수 없습니다."));
+    if (!msg.getSenderId().equals(senderId)) {
+      throw new SecurityException("해당 메시지를 수정할 권한이 없습니다.");
+    }
+
+    msg.updateContent(newContent);
+    messageRepository.save(msg);
+  }
+
+  @Override
+  public void deleteMessage(UUID messageId, UUID senderId) {
+    Message msg = messageRepository.findById(messageId)
+        .orElseThrow(() -> new IllegalArgumentException("메시지를 찾을 수 없습니다."));
+    if (!msg.getSenderId().equals(senderId)) {
+      throw new SecurityException("해당 메시지를 삭제할 권한이 없습니다.");
+    }
+
+    messageRepository.delete(messageId);
+    messageRepository.removeFromChannel(msg.getChannelId(), msg);
+    messageRepository.removeFromUser(senderId, msg);
+  }
+
+  @Override
+  public List<Message> getAllMessagesInChannel(UUID channelId, UUID requesterId) {
+    Channel channel = channelService.getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("채널이 존재하지 않습니다."));
+    if (channel.getChannelUsers().stream().noneMatch(u -> u.getId().equals(requesterId))) {
+      throw new SecurityException("채널에 접근할 수 있는 권한이 없습니다.");
+    }
+
+    return messageRepository.findByChannelId(channelId);
+  }
+
+  public Optional<Message> getMessageById(UUID messageId) {
+    return messageRepository.findById(messageId);
+  }
+
+  public String formatMessage(Message message) {
+    boolean isEdited = !message.getCreatedAt().equals(message.getUpdatedAt());
+    long timestamp = isEdited ? message.getUpdatedAt() : message.getCreatedAt();
+    String formattedDate = DATE_FORMAT.format(new Date(timestamp));
+
+    Optional<User> senderOpt = userService.getUserById(message.getSenderId());
+    String senderName = senderOpt.map(User::getUsername).orElse("알 수 없음");
+    String senderEmail = senderOpt.map(User::getEmail).orElse("이메일 없음");
+
+    String channelName = channelService.getChannelById(message.getChannelId())
+        .map(Channel::getChannelName)
+        .orElse("알 수 없음");
+
+    return String.format("[%s] %s, 보낸사람: %s(%s), 내용: \"%s\"",
+        channelName, formattedDate, senderName, senderEmail, message.getContent());
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
@@ -1,0 +1,88 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.service.UserService;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class BasicUserService implements UserService {
+
+  private final UserRepository userRepository;
+  private ChannelService channelService;
+
+  // 생성자를 통해 Repository 주입
+  public BasicUserService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  // 순환 참조 방지를 위한 setter 주입
+  public void setChannelService(ChannelService channelService) {
+    this.channelService = channelService;
+  }
+
+  @Override
+  public User createUser(String username, String email) {
+    if (isEmailDuplicate(email)) {
+      throw new IllegalArgumentException("이미 존재하는 이메일입니다: " + email);
+    }
+    User user = new User(username, email);
+    userRepository.save(user);
+    return user;
+  }
+
+  @Override
+  public Optional<User> getUserById(UUID id) {
+    return userRepository.getUserById(id);
+  }
+
+  @Override
+  public List<User> getAllUsers() {
+    return userRepository.getAllUsers();
+  }
+
+  public void updateUserName(UUID id, String name) {
+    User user = userRepository.getUserById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id));
+
+    user.updateName(name);
+    userRepository.update(user);
+  }
+
+  public void updateUserEmail(UUID id, String email) {
+    User user = userRepository.getUserById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id));
+
+    if (user.getEmail().equalsIgnoreCase(email)) {
+      throw new IllegalArgumentException("기존과 동일한 이메일입니다.");
+    }
+
+    if (isEmailDuplicate(email)) {
+      throw new IllegalArgumentException("이미 존재하는 이메일입니다: " + email);
+    }
+
+    user.updateEmail(email);
+    userRepository.update(user);
+  }
+
+  @Override
+  public void deleteUser(UUID id) {
+    User user = userRepository.getUserById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id));
+
+    if (channelService != null) {
+      channelService.deleteChannelsCreatedByUser(id);
+      channelService.removeUserFromAllChannels(id);
+    }
+
+    userRepository.delete(id);
+  }
+
+  private boolean isEmailDuplicate(String email) {
+    return userRepository.getAllUsers().stream()
+        .anyMatch(user -> user.getEmail().equalsIgnoreCase(email));
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/factory/ServiceFactory.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/factory/ServiceFactory.java
@@ -2,6 +2,8 @@ package com.sprint.mission.discodeit.service.factory;
 
 import com.sprint.mission.discodeit.service.ChannelService;
 import com.sprint.mission.discodeit.service.UserService;
+import com.sprint.mission.discodeit.service.file.FileChannelService;
+import com.sprint.mission.discodeit.service.file.FileUserService;
 import com.sprint.mission.discodeit.service.jcf.JcfChannelService;
 import com.sprint.mission.discodeit.service.jcf.JcfUserService;
 
@@ -14,8 +16,8 @@ public class ServiceFactory {
   private static ChannelService channelService;
 
   public static void initializeServices() {
-    JcfUserService user = new JcfUserService();  //  먼저 JcfUserService를 비워서 생성한다.
-    channelService = new JcfChannelService(user); // JcfChannelService에 유저서비스를 넣는다.
+    FileUserService user = new FileUserService();  //  먼저 Jcf(File)UserService를 비워서 생성한다.
+    channelService = new FileChannelService(user); // Jcf(File)ChannelService에 유저서비스를 넣는다.
     user.setChannelService(channelService); // 생성된 channelService를 setter로 주입한다.
     userService = user;
   }

--- a/src/main/java/com/sprint/mission/discodeit/service/file/FileChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/file/FileChannelService.java
@@ -1,0 +1,140 @@
+package com.sprint.mission.discodeit.service.file;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.service.UserService;
+
+import java.io.*;
+import java.util.*;
+
+public class FileChannelService implements ChannelService {
+  private static final String FILE_PATH = "channels.ser";
+  private final Map<UUID, Channel> channelData;
+  private final UserService userService;
+
+  public FileChannelService(UserService userService) {
+    this.userService = userService;
+    this.channelData = loadChannelData();
+  }
+
+  private void saveChannelData() {
+    try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(FILE_PATH))) {
+      oos.writeObject(channelData);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private Map<UUID, Channel> loadChannelData() {
+    File file = new File(FILE_PATH);
+    if (!file.exists()) {
+      return new HashMap<>();
+    }
+    try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
+      return (Map<UUID, Channel>) ois.readObject();
+    } catch (IOException | ClassNotFoundException e) {
+      e.printStackTrace();
+      return new HashMap<>();
+    }
+  }
+
+  @Override
+  public Channel createChannel(String channelName, User ownerUser) {
+    boolean isDuplicate = channelData.values().stream()
+        .anyMatch(c -> c.getChannelOwner().getId().equals(ownerUser.getId())
+            && c.getChannelName().equals(channelName));
+
+    if (isDuplicate) {
+      throw new IllegalArgumentException("이미 같은 이름의 채널이 존재합니다. 다른 이름을 설정해주세요.");
+    }
+
+    List<User> members = new ArrayList<>();
+    members.add(ownerUser);
+    Channel channel = new Channel(channelName, ownerUser, members);
+    channelData.put(channel.getId(), channel);
+    saveChannelData();
+    return channel;
+  }
+
+  @Override
+  public Optional<Channel> getChannelById(UUID channelId) {
+    return Optional.ofNullable(channelData.get(channelId));
+  }
+
+  @Override
+  public List<Channel> getAllChannels() {
+    return new ArrayList<>(channelData.values());
+  }
+
+  @Override
+  public void updateChannelName(UUID channelId, String newChannelName) {
+    Channel channel = getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 채널이 존재하지 않습니다."));
+
+    if (channel.getChannelName().equals(newChannelName)) {
+      throw new IllegalArgumentException("채널 이름이 기존과 동일합니다.");
+    }
+
+    UUID ownerId = channel.getChannelOwner().getId();
+    boolean isDuplicate = channelData.values().stream()
+        .anyMatch(c -> c.getChannelOwner().getId().equals(ownerId)
+            && c.getChannelName().equals(newChannelName));
+
+    if (isDuplicate) {
+      throw new IllegalArgumentException("해당 채널명은 이미 사용 중입니다.");
+    }
+
+    channel.updateChannelName(newChannelName);
+    saveChannelData();
+  }
+
+  @Override
+  public void deleteChannel(UUID channelId) {
+    channelData.remove(channelId);
+    saveChannelData();
+  }
+
+  @Override
+  public void addMember(UUID channelId, UUID userId) {
+    Channel channel = getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채널 ID입니다."));
+    User user = userService.getUserById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 ID입니다."));
+
+    channel.addChannelUser(user);
+    saveChannelData();
+  }
+
+  @Override
+  public void removeMember(UUID channelId, UUID userId) {
+    Channel channel = getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채널 ID입니다."));
+    User user = userService.getUserById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 ID입니다."));
+
+    channel.removeChannelUser(user);
+    saveChannelData();
+  }
+
+  @Override
+  public List<User> getChannelMembers(UUID channelId) {
+    Channel channel = getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채널 ID입니다."));
+    return new ArrayList<>(channel.getChannelUsers());
+  }
+
+  @Override
+  public void deleteChannelsCreatedByUser(UUID userId) {
+    channelData.entrySet().removeIf(entry -> entry.getValue().getChannelOwner().getId().equals(userId));
+    saveChannelData();
+  }
+
+  @Override
+  public void removeUserFromAllChannels(UUID userId) {
+    for (Channel channel : channelData.values()) {
+      channel.getChannelUsers().removeIf(user -> user.getId().equals(userId));
+    }
+    saveChannelData();
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/file/FileMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/file/FileMessageService.java
@@ -1,0 +1,185 @@
+package com.sprint.mission.discodeit.service.file;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.service.MessageService;
+import com.sprint.mission.discodeit.service.UserService;
+
+import java.io.*;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+public class FileMessageService implements MessageService {
+  private static final String FILE_PATH = "messages.ser";
+
+  private Map<UUID, Message> messageMap = new HashMap<>();
+  private Map<UUID, List<Message>> channelMessagesMap = new HashMap<>();
+  private Map<UUID, List<Message>> userMessagesMap = new HashMap<>();
+
+  private final UserService userService;
+  private final ChannelService channelService;
+  private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("MM월 dd일 a hh시 mm분 ss초");
+
+  public FileMessageService(UserService userService, ChannelService channelService) {
+    this.userService = userService;
+    this.channelService = channelService;
+    loadData();
+  }
+
+  private void loadData() {
+    File file = new File(FILE_PATH);
+    if (!file.exists()) return;
+
+    try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
+      messageMap = (Map<UUID, Message>) ois.readObject();
+      channelMessagesMap = (Map<UUID, List<Message>>) ois.readObject();
+      userMessagesMap = (Map<UUID, List<Message>>) ois.readObject();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void saveData() {
+    try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(FILE_PATH))) {
+      oos.writeObject(messageMap);
+      oos.writeObject(channelMessagesMap);
+      oos.writeObject(userMessagesMap);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public Message createMessage(UUID channelId, UUID senderId, String content) {
+    Channel channel = channelService.getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 채널이 존재하지 않습니다."));
+    User sender = userService.getUserById(senderId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 ID입니다. senderId: " + senderId));
+
+    if (channel.getChannelUsers().size() < 2) {
+      throw new IllegalStateException("채널에 최소 두 명 이상의 유저가 있어야 메시지를 보낼 수 있습니다.");
+    }
+    if (!channel.getChannelUsers().contains(sender)) {
+      throw new IllegalArgumentException("해당 유저는 이 채널의 멤버가 아닙니다.");
+    }
+
+    Message message = new Message(content, channelId, senderId);
+    messageMap.put(message.getId(), message);
+    channelMessagesMap.computeIfAbsent(channelId, k -> new ArrayList<>()).add(message);
+    userMessagesMap.computeIfAbsent(senderId, k -> new ArrayList<>()).add(message);
+
+    saveData();
+    return message;
+  }
+
+  @Override
+  public List<Message> getMessagesBySenderInChannel(UUID channelId, UUID senderId) {
+    Channel channel = channelService.getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 채널이 존재하지 않습니다."));
+    if (channel.getChannelUsers().stream().noneMatch(u -> u.getId().equals(senderId))) {
+      throw new IllegalArgumentException("해당 유저는 이 채널의 멤버가 아닙니다.");
+    }
+
+    return channelMessagesMap.getOrDefault(channelId, Collections.emptyList())
+        .stream()
+        .filter(m -> m.getSenderId().equals(senderId))
+        .toList();
+  }
+
+  @Override
+  public List<Message> getMessagesByReceiverInChannel(UUID channelId, UUID receiverId) {
+    Channel channel = channelService.getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 채널이 존재하지 않습니다."));
+
+    if (channel.getChannelUsers().stream().noneMatch(u -> u.getId().equals(receiverId))) {
+      throw new IllegalArgumentException("해당 유저는 이 채널의 멤버가 아닙니다.");
+    }
+
+    return channelMessagesMap.getOrDefault(channelId, Collections.emptyList())
+        .stream()
+        .filter(m -> !m.getSenderId().equals(receiverId))
+        .toList();
+  }
+
+  @Override
+  public List<Message> getAllSentMessages(UUID senderId) {
+    return userMessagesMap.getOrDefault(senderId, Collections.emptyList());
+  }
+
+  @Override
+  public List<Message> getAllReceivedMessages(UUID receiverId) {
+    List<UUID> myChannels = channelService.getAllChannels().stream()
+        .filter(ch -> ch.getChannelUsers().stream().anyMatch(u -> u.getId().equals(receiverId)))
+        .map(Channel::getId)
+        .toList();
+
+    List<Message> received = new ArrayList<>();
+    for (UUID chId : myChannels) {
+      List<Message> messages = channelMessagesMap.getOrDefault(chId, Collections.emptyList());
+      for (Message msg : messages) {
+        if (!msg.getSenderId().equals(receiverId)) {
+          received.add(msg);
+        }
+      }
+    }
+    return received;
+  }
+
+  @Override
+  public void updateMessage(UUID messageId, UUID senderId, String newContent) {
+    Message msg = messageMap.get(messageId);
+    if (msg == null) throw new IllegalArgumentException("메시지를 찾을 수 없습니다.");
+    if (!msg.getSenderId().equals(senderId)) {
+      throw new SecurityException("해당 메시지를 수정할 권한이 없습니다.");
+    }
+    msg.updateContent(newContent);
+    saveData();
+  }
+
+  @Override
+  public void deleteMessage(UUID messageId, UUID senderId) {
+    Message msg = messageMap.get(messageId);
+    if (msg == null) throw new IllegalArgumentException("메시지를 찾을 수 없습니다.");
+    if (!msg.getSenderId().equals(senderId)) {
+      throw new SecurityException("해당 메시지를 삭제할 권한이 없습니다.");
+    }
+    messageMap.remove(messageId);
+    channelMessagesMap.getOrDefault(msg.getChannelId(), new ArrayList<>()).remove(msg);
+    userMessagesMap.getOrDefault(senderId, new ArrayList<>()).remove(msg);
+    saveData();
+  }
+
+  @Override
+  public List<Message> getAllMessagesInChannel(UUID channelId, UUID requesterId) {
+    Channel channel = channelService.getChannelById(channelId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 채널이 존재하지 않습니다."));
+    if (channel.getChannelUsers().stream().noneMatch(u -> u.getId().equals(requesterId))) {
+      throw new SecurityException("채널에 접근할 수 있는 권한이 없습니다.");
+    }
+
+    return channelMessagesMap.getOrDefault(channelId, Collections.emptyList());
+  }
+
+  public Optional<Message> getMessageById(UUID messageId) {
+    return Optional.ofNullable(messageMap.get(messageId));
+  }
+
+  public String formatMessage(Message message) {
+    boolean isEdited = !message.getCreatedAt().equals(message.getUpdatedAt());
+    long timestamp = isEdited ? message.getUpdatedAt() : message.getCreatedAt();
+    String formattedDate = DATE_FORMAT.format(new Date(timestamp));
+
+    Optional<User> senderOpt = userService.getUserById(message.getSenderId());
+    String senderName = senderOpt.map(User::getUsername).orElse("알 수 없음");
+    String senderEmail = senderOpt.map(User::getEmail).orElse("이메일 없음");
+
+    String channelName = channelService.getChannelById(message.getChannelId())
+        .map(Channel::getChannelName)
+        .orElse("알 수 없음");
+
+    return String.format("[%s] %s, 보낸사람: %s(%s), 내용: \"%s\"",
+        channelName, formattedDate, senderName, senderEmail, message.getContent());
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/file/FileUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/file/FileUserService.java
@@ -1,0 +1,106 @@
+package com.sprint.mission.discodeit.service.file;
+
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.service.UserService;
+
+import java.io.*;
+import java.util.*;
+
+public class FileUserService implements UserService {
+  private static final String FILE_PATH = "users.ser";
+  private final Map<UUID, User> userData;
+  private ChannelService channelService;
+
+  public FileUserService() {
+    this.userData = loadUserData(); // 파일에서 데이터 로드
+  }
+
+  public void setChannelService(ChannelService channelService) {
+    this.channelService = channelService;
+  }
+
+  private void saveUserData() {
+    try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(FILE_PATH))) {
+      oos.writeObject(userData); // 데이터를 파일에 저장
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private Map<UUID, User> loadUserData() {
+    File file = new File(FILE_PATH);
+    if (!file.exists()) {
+      return new HashMap<>(); // 파일이 없으면 빈 Map 반환
+    }
+    try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
+      return (Map<UUID, User>) ois.readObject(); // 파일에서 데이터 읽기
+    } catch (IOException | ClassNotFoundException e) {
+      e.printStackTrace();
+      return new HashMap<>(); // 오류가 발생하면 빈 Map 반환
+    }
+  }
+
+  @Override
+  public User createUser(String username, String email) {
+    if (isEmailDuplicate(email)) {
+      throw new IllegalArgumentException("이미 존재하는 이메일입니다: " + email);
+    }
+    User user = new User(username, email);
+    userData.put(user.getId(), user);
+    saveUserData();
+    return user;
+  }
+
+  @Override
+  public Optional<User> getUserById(UUID id) {
+    return Optional.ofNullable(userData.get(id));
+  }
+
+  @Override
+  public List<User> getAllUsers() {
+    return new ArrayList<>(userData.values());
+  }
+
+  public void updateUserName(UUID id, String name) {
+    User user = getUserById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id));
+    user.updateName(name);
+    saveUserData();
+  }
+
+  public void updateUserEmail(UUID id, String email) {
+    User user = getUserById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id));
+
+    if (user.getEmail().equalsIgnoreCase(email)) {
+      throw new IllegalArgumentException("기존과 동일한 이메일입니다.");
+    }
+
+    if (isEmailDuplicate(email)) {
+      throw new IllegalArgumentException("이미 존재하는 이메일입니다: " + email);
+    }
+
+    user.updateEmail(email);
+    saveUserData();
+  }
+
+  @Override
+  public void deleteUser(UUID id) {
+    User user = getUserById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id));
+
+    if (channelService != null) {
+      channelService.deleteChannelsCreatedByUser(id);
+      channelService.removeUserFromAllChannels(id);
+    }
+
+    userData.remove(id);
+    saveUserData();
+  }
+
+  private boolean isEmailDuplicate(String email) {
+    return userData.values().stream()
+        .anyMatch(user -> user.getEmail().equalsIgnoreCase(email)); // 이메일 중복 검사
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/jcf/JcfUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/jcf/JcfUserService.java
@@ -32,11 +32,11 @@ public class JcfUserService implements UserService {
   }
 
   @Override
-  public User getUserById(UUID id) {
+  public Optional<User> getUserById(UUID id) {
     return data.stream()
         .filter(e -> e.getId().equals(id))
-        .findFirst() // UUID는 유일하므로 첫 번째 결과 반환. 만약 비어있으면 Optional.empty()를 반환
-        .orElse(null); // 유저가 없으면 null 반환
+        .findFirst(); // UUID는 유일하므로 첫 번째 결과 반환. 만약 비어있으면 Optional.empty()를 반환
+    //.orElse(null); // 유저가 없으면 null 반환
     //  .orElseThrow(() -> new IllegalArgumentException("조회할 User를 찾지 못했습니다."));
   /*
     //직관적인 foreach문
@@ -55,18 +55,14 @@ public class JcfUserService implements UserService {
   }
 
   public void updateUserName(UUID id, String name) {
-    User user = getUserById(id);
-    if (user == null) {
-      throw new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id);
-    }
+    User user = getUserById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id));
     user.updateName(name);
   }
 
   public void updateUserEmail(UUID id, String email) {
-    User user = getUserById(id);
-    if (user == null) {
-      throw new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id);
-    }
+    User user = getUserById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id));
 
     if (user.getEmail().equalsIgnoreCase(email)) {
       throw new IllegalArgumentException("기존과 동일한 이메일입니다.");
@@ -81,10 +77,8 @@ public class JcfUserService implements UserService {
 
   @Override
   public void deleteUser(UUID id) { // 유저가 삭제되면, 그 유저가 만든 채널도 함께 삭제되도록 연동이 필요
-    User user = getUserById(id);
-    if (user == null) {
-      throw new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id);
-    }
+    User user = getUserById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id));
 
     if (channelService != null) {
       channelService.deleteChannelsCreatedByUser(id);   // 유저가 만든 채널 삭제

--- a/src/main/java/com/sprint/mission/discodeit/service/jcf/JcfUserServiceUsingMap.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/jcf/JcfUserServiceUsingMap.java
@@ -21,8 +21,8 @@ public class JcfUserServiceUsingMap implements UserService {
   }
 
   @Override
-  public User getUserById(UUID id) {
-    return data.get(id);
+  public Optional<User> getUserById(UUID id) {
+    return Optional.ofNullable(data.get(id));
     //return Optional.ofNullable(users.get(id)).orElseThrow(() -> new IllegalArgumentException("조회할 User를 찾지 못했습니다."));
   }
 
@@ -33,7 +33,8 @@ public class JcfUserServiceUsingMap implements UserService {
 
   @Override
   public void updateUserName(UUID id, String name) {
-    User user = getUserById(id); // 존재하는지 확인
+    User user = getUserById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id)); // 존재하는지 확인
     //User user = Optional.ofNullable(users.get(id))
     //        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id));
     user.updateName(name);
@@ -41,8 +42,9 @@ public class JcfUserServiceUsingMap implements UserService {
 
   @Override
   public void updateUserEmail(UUID id, String email) {
-    User user = getUserById(id); // 존재하는지 확인
-    user.updateName(email);
+    User user = getUserById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + id)); // 존재하는지 확인
+    user.updateEmail(email);
   }
 
   @Override


### PR DESCRIPTION
기본 요구사항
File IO를 통한 데이터 영속화
[ ]  다음의 조건을 만족하는 서비스 인터페이스의 구현체를 작성하세요.
[ ]  클래스 패키지명: com.sprint.mission.discodeit.service.file
[ ]  클래스 네이밍 규칙: File[인터페이스 이름]
[ ]  JCF 대신 FileIO와 객체 직렬화를 활용해 메소드를 구현하세요.
[객체 직렬화/역직렬화 가이드](https://www.notion.so/13b6fd228e8d80c6b144cdfbf518a9f7?pvs=21)
[ ]  Application에서 서비스 구현체를 File*Service로 바꾸어 테스트해보세요.

서비스 구현체 분석
[ ] JCF*Service 구현체와 File*Service 구현체를 비교하여 공통점과 차이점을 발견해보세요.
[ ] "비즈니스 로직"과 관련된 코드를 식별해보세요.
[ ] "저장 로직"과 관련된 코드를 식별해보세요.

레포지토리 설계 및 구현
[ ] "저장 로직"과 관련된 기능을 도메인 모델 별 인터페이스로 선언하세요.
[ ] 인터페이스 패키지명: com.sprint.mission.discodeit.repository
[ ] 인터페이스 네이밍 규칙: [도메인 모델 이름]Repository
[ ] 다음의 조건을 만족하는 레포지토리 인터페이스의 구현체를 작성하세요.
[ ] 클래스 패키지명: com.sprint.mission.discodeit.repository.jcf
[ ] 클래스 네이밍 규칙: JCF[인터페이스 이름]
[ ] 기존에 구현한 JCF*Service 구현체의 "저장 로직"과 관련된 코드를 참고하여 구현하세요.
[ ] 다음의 조건을 만족하는 레포지토리 인터페이스의 구현체를 작성하세요.
[ ] 클래스 패키지명: com.sprint.mission.discodeit.repository.file
[ ] 클래스 네이밍 규칙: File[인터페이스 이름]
[ ] 기존에 구현한 File*Service 구현체의 "저장 로직"과 관련된 코드를 참고하여 구현하세요.

심화 요구 사항
관심사 분리를 통한 레이어 간 의존성 주입
[ ] 다음의 조건을 만족하는 서비스 인터페이스의 구현체를 작성하세요.
[ ] 클래스 패키지명: com.sprint.mission.discodeit.service.basic
[ ] 클래스 네이밍 규칙: Basic[인터페이스 이름]
[ ] 기존에 구현한 서비스 구현체의 "비즈니스 로직"과 관련된 코드를 참고하여 구현하세요.
[ ] 필요한 Repository 인터페이스를 필드로 선언하고 생성자를 통해 초기화하세요.
[ ] "저장 로직"은 Repository 인터페이스 필드를 활용하세요. (직접 구현하지 마세요.)
[ ] Basic*Service 구현체를 활용하여 테스트해보세요.

[ ]  JCF*Repository  구현체를 활용하여 테스트해보세요.
[ ]  File*Repository 구현체를 활용하여 테스트해보세요.
[ ] 이전에 작성했던 코드(JCF*Service 또는 File*Service)와 비교해 어떤 차이가 있는지 정리해보세요.  


JCF*Service 구현체와 File*Service 구현체를 비교하여 공통점과 차이점 정리
1. JcfUserService (메모리 기반 서비스)
 비즈니스 로직:
createUser(String username, String email): 유저를 생성하고, 이메일 중복을 확인한 후 유저 객체를 추가
getUserById(UUID id): 주어진 ID로 유저를 조회
getAllUsers(): 모든 유저를 리스트로 반환
updateUserName(UUID id, String name): 유저 이름을 업데이트
updateUserEmail(UUID id, String email): 유저 이메일을 업데이트
deleteUser(UUID id): 유저를 삭제하고, 그 유저가 만든 채널도 삭제
isEmailDuplicate(String email): 이메일 중복 여부를 확인
 저장 로직:
data.add(user): 유저를 리스트에 추가
data.remove(user): 유저를 리스트에서 삭제

2. FileUserService (파일 기반 서비스)
 비즈니스 로직:
createUser(String username, String email)
getUserById(UUID id)
getAllUsers()
updateUserName(UUID id, String name)
updateUserEmail(UUID id, String email)
deleteUser(UUID id)
isEmailDuplicate(String email)
 저장 로직:
loadUserData(): 파일에서 데이터를 불러옴
saveUserData(): 데이터를 파일에 저장
userData.put(user.getId(), user): 유저를 파일 기반 Map에 추가
userData.remove(id): 유저를 파일 기반 Map에서 삭제

 두 UserService 구현클래스의 비즈니스 로직은 거의 동일, 저장 로직은 
FileUserService에서 파일 I/O 작업을 통해 파일에 데이터를 저장하는 영속화 로직을 포함
JcfUserService는 단순히 리스트에 데이터를 저장하고 삭제하는 메모리 기반의 로직을 사용


3. JcfChannelService 
 비즈니스 로직:
createChannel(String channelName, User ownerUser): 채널 생성, 채널 이름 중복 확인, 채널 객체를 리스트에 추가
getChannelById(UUID channelId): 주어진 ID로 채널을 조회
getAllChannels(): 모든 채널을 리스트로 반환
updateChannelName(UUID channelId, String newChannelName): 채널 이름을 업데이트, 중복된 이름은 예외를 발생
deleteChannel(UUID channelId): 채널을 리스트에서 삭제
addMember(UUID channelId, UUID userId): 채널에 유저를 추가
removeMember(UUID channelId, UUID userId): 채널에서 유저를 제거
getChannelMembers(UUID channelId): 채널의 모든 멤버를 반환
deleteChannelsCreatedByUser(UUID userId): 특정 유저가 만든 모든 채널을 삭제
removeUserFromAllChannels(UUID userId): 특정 유저를 모든 채널에서 제거

 저장 로직:
channels.add(channel): 채널을 메모리 기반 리스트에 추가
channels.remove(channel): 채널을 메모리 기반 리스트에서 삭제
channels.removeIf(...): 주어진 조건에 맞는 채널을 리스트에서 제거

4. FileChannelService (파일 기반 서비스)
 비즈니스 로직:
createChannel(String channelName, User ownerUser): 
getChannelById(UUID channelId): 
getAllChannels(): 
updateChannelName(UUID channelId, String newChannelName)
deleteChannel(UUID channelId)
addMember(UUID channelId, UUID userId)
removeMember(UUID channelId, UUID userId)
getChannelMembers(UUID channelId)
deleteChannelsCreatedByUser(UUID userId)
removeUserFromAllChannels(UUID userId)
 
 저장 로직:
loadChannelData(): 파일에서 채널 데이터를 불러옴
saveChannelData(): 파일에 채널 데이터를 저장
channelData.put(channel.getId(), channel): 채널을 파일 기반 Map에 추가
channelData.remove(channelId): 채널을 파일 기반 Map에서 삭제
channelData.entrySet().removeIf(...): 주어진 조건에 맞는 채널을 파일 기반 Map에서 제거

 두 channelService 구현클래스는 거의 동일한 비즈니스 로직을 수행, 저장 로직에서는 
FileChannelService는 파일 I/O 작업을 통해 데이터를 파일에 저장하고, 프로그램이 종료된 후에도 데이터를 불러올 수 있다.
JcfChannelService는 데이터를 메모리에만 저장하여 프로그램 종료 시 데이터가 사라진다. 

5. JcfMessageService
 비즈니스 로직:
createMessage(UUID channelId, UUID userId, String content): 메시지 생성 및 해당 채널에 추가
getMessageById(UUID messageId): ID로 메시지 조회
getAllMessages(UUID channelId): 특정 채널의 모든 메시지 반환
getAllSentMessages(UUID userId): 사용자가 보낸 메시지 전체 반환
getAllReceivedMessages(UUID userId): 사용자가 받은 메시지 전체 반환
getMessagesByUser(UUID userId): 사용자가 보낸 메시지 리스트 반환
updateMessage(UUID messageId, String newContent): 메시지 내용 수정
deleteMessage(UUID messageId): 메시지 삭제
deleteMessagesByUserId(UUID userId): 특정 유저가 작성한 메시지 전부 삭제
deleteMessagesByChannelId(UUID channelId): 특정 채널에 있는 메시지 전부 삭제
 저장 로직 
messages.add(message): 메시지를 리스트/Map에 추가
messages.remove(message): 메시지를 리스트/Map에서 삭제

6. FileMessageService (파일 기반 서비스)
 비즈니스 로직:
createMessage(UUID channelId, UUID userId, String content)
getMessageById(UUID messageId)
getAllMessages(UUID channelId)
getAllSentMessages(UUID userId)
getAllReceivedMessages(UUID userId)
getMessagesByUser(UUID userId)
updateMessage(UUID messageId, String newContent)
deleteMessage(UUID messageId)
deleteMessagesByUserId(UUID userId)
deleteMessagesByChannelId(UUID channelId)
 저장 로직:
loadMessageData(): 파일에서 메시지 데이터를 불러옴
saveMessageData(): 파일에 메시지 데이터를 저장
messageData.put(message.getId(), message): 메시지를 파일 기반 Map에 추가
messageData.remove(messageId): 메시지를 파일 기반 Map에서 삭제

 두 messageService 구현클래스는 거의 비슷한 비즈니스 로직을 수행. 저장 방식은
FileMessage는 파일 I/O 작업을 통해 메시지 데이터를 파일에 저장하고, 프로그램 종료 후에도 데이터를 복원가능
JcfMessage는 메모리 기반 리스트에 메시지를 저장하며, 프로그램 종료 시 데이터가 사라진다.

 JcfUserService와 BasicUserService 차이
// 데이터 저장 방식	
직접 List<User>에 저장 메모리 리스트 사용 <> UserRepository와 연결해서 처리
// 책임 분리	
서비스가 직접 데이터를 관리 <> 데이터 저장은 Repository, 서비스는 비즈니스 로직만 담당

 FileChannelService 와  BasicChannelService 의 차이
// 데이터 저장 방식
직접 파일(channels.ser)에 저장 <> ChannelRepository와 연결해서 처리
// 책임 분리	
저장소 역할과 비즈니스 로직을 모두 처리 <> 비즈니스 로직만 담당, 저장은 Repository가 처리
