### PR TITLE
[박진솔] sprint11

### DIFF
--- a/3-sprint-mission/build.gradle
+++ b/3-sprint-mission/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'com.nimbusds:nimbus-jose-jwt:10.3'
     runtimeOnly 'org.postgresql:postgresql'
+    implementation 'org.springframework.retry:spring-retry'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/config/AppConfig.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/config/AppConfig.java
@@ -2,11 +2,13 @@ package com.sprint.mission.discodeit.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableJpaAuditing
 @EnableScheduling
+@EnableRetry
 public class AppConfig {
 
 }

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/config/AsyncConfig.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/config/AsyncConfig.java
@@ -1,0 +1,61 @@
+package com.sprint.mission.discodeit.config;
+
+import java.util.List;
+import java.util.Optional;
+import org.jboss.logging.MDC;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.support.CompositeTaskDecorator;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@EnableAsync
+public class AsyncConfig {
+
+  @Bean(name = "eventTaskExecutor")
+  public TaskExecutor eventExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(2);
+    executor.setMaxPoolSize(4);
+    executor.setQueueCapacity(100);
+    executor.setThreadNamePrefix("event-task-");
+    executor.setTaskDecorator(
+        new CompositeTaskDecorator(List.of(mdcTaskDecorator(), securityContextTaskDecorator())));
+    executor.initialize();
+    return executor;
+  }
+
+  public TaskDecorator mdcTaskDecorator() {
+    return runnable -> {
+      Optional<String> requestId = Optional.ofNullable(MDC.get(MDCLoggingInterceptor.REQUEST_ID))
+          .map(String.class::cast);
+      return () -> {
+        requestId.ifPresent(id -> MDC.put(MDCLoggingInterceptor.REQUEST_ID, id));
+        try {
+          runnable.run();
+        } finally {
+          requestId.ifPresent(id -> MDC.remove(MDCLoggingInterceptor.REQUEST_ID));
+        }
+      };
+    };
+  }
+
+  public TaskDecorator securityContextTaskDecorator() {
+    return runnable -> {
+      SecurityContext securityContext = SecurityContextHolder.getContext();
+      return () -> {
+        SecurityContextHolder.setContext(securityContext);
+        try {
+          runnable.run();
+        } finally {
+          SecurityContextHolder.clearContext();
+        }
+      };
+    };
+  }
+
+
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/controller/MessageController.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/controller/MessageController.java
@@ -7,6 +7,7 @@ import com.sprint.mission.discodeit.dto.request.MessageCreateRequest;
 import com.sprint.mission.discodeit.dto.request.MessageUpdateRequest;
 import com.sprint.mission.discodeit.dto.response.PageResponse;
 import com.sprint.mission.discodeit.service.MessageService;
+import io.micrometer.core.annotation.Timed;
 import jakarta.validation.Valid;
 import java.io.IOException;
 import java.time.Instant;
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
@@ -32,7 +34,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -42,14 +43,15 @@ public class MessageController implements MessageApi {
 
   private final MessageService messageService;
 
+  @Timed("message.create.async")
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<MessageDto> create(
       @RequestPart("messageCreateRequest") @Valid MessageCreateRequest messageCreateRequest,
       @RequestPart(value = "attachments", required = false) List<MultipartFile> attachments
   ) {
-    log.info("메시지 생성 요청: request={}, attachmentCount={}", 
+    log.info("메시지 생성 요청: request={}, attachmentCount={}",
         messageCreateRequest, attachments != null ? attachments.size() : 0);
-    
+
     List<BinaryContentCreateRequest> attachmentRequests = Optional.ofNullable(attachments)
         .map(files -> files.stream()
             .map(file -> {
@@ -104,7 +106,7 @@ public class MessageController implements MessageApi {
           sort = "createdAt",
           direction = Direction.DESC
       ) Pageable pageable) {
-    log.info("채널별 메시지 목록 조회 요청: channelId={}, cursor={}, pageable={}", 
+    log.info("채널별 메시지 목록 조회 요청: channelId={}, cursor={}, pageable={}",
         channelId, cursor, pageable);
     PageResponse<MessageDto> messages = messageService.findAllByChannelId(channelId, cursor,
         pageable);

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/controller/NotificationController.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/controller/NotificationController.java
@@ -1,0 +1,57 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.entity.DiscodeitUserDetails;
+import com.sprint.mission.discodeit.service.NotificationService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  @GetMapping
+  public ResponseEntity<List<NotificationDto>> getNotifications(
+      @AuthenticationPrincipal DiscodeitUserDetails userDetails) {
+
+    log.info("알림 조회 요청: userId={}", userDetails.getUserDto().id());
+
+    List<NotificationDto> notifications = notificationService
+        .findAllByReceiverId(userDetails.getUserDto().id());
+
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .body(notifications);
+  }
+
+  @DeleteMapping("/{notificationId}")
+  @PreAuthorize("@notificationService.isNotificationOwner(#notificationId, principal.userDto.id)")
+  public ResponseEntity<Void> deleteNotification(
+      @PathVariable UUID notificationId,
+      @AuthenticationPrincipal DiscodeitUserDetails userDetails) {
+
+    log.info("알림 확인 처리 요청: notificationId={}, userId={}",
+        notificationId, userDetails.getUserDto().id());
+
+    notificationService.deleteByIdAndReceiverId(notificationId, userDetails.getUserDto().id());
+
+    return ResponseEntity
+        .status(HttpStatus.NO_CONTENT)
+        .build();
+  }
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/dto/data/NotificationDto.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/dto/data/NotificationDto.java
@@ -1,0 +1,14 @@
+package com.sprint.mission.discodeit.dto.data;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationDto(
+    UUID id,
+    Instant createdAt,
+    UUID receivedId,
+    String title,
+    String content
+) {
+
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/dto/request/ReadStatusUpdateRequest.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/dto/request/ReadStatusUpdateRequest.java
@@ -7,7 +7,9 @@ import java.time.Instant;
 public record ReadStatusUpdateRequest(
     @NotNull(message = "새로운 마지막 읽은 시간은 필수입니다")
     @PastOrPresent(message = "마지막 읽은 시간은 현재 또는 과거 시간이어야 합니다")
-    Instant newLastReadAt
+    Instant newLastReadAt,
+    @NotNull
+    boolean newNotificationEnabled
 ) {
 
 }

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
@@ -20,10 +20,19 @@ public class BinaryContent extends BaseEntity {
   private Long size;
   @Column(length = 100, nullable = false)
   private String contentType;
+  @Column(length = 20, nullable = false)
+  private BinaryContentStatus status;
 
   public BinaryContent(String fileName, Long size, String contentType) {
     this.fileName = fileName;
     this.size = size;
     this.contentType = contentType;
+    this.status = BinaryContentStatus.PROCESSING;
   }
+
+  // 상태 변경 메서드들 (트랜잭션은 호출 측 서비스에서 관리)
+  public void updateStatus(BinaryContentStatus status) {
+    this.status = status;
+  }
+
 }

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/entity/BinaryContentStatus.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/entity/BinaryContentStatus.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.entity;
+
+public enum BinaryContentStatus {
+    PROCESSING, // 업로드 중 (기본값)
+    SUCCESS,    // 업로드 완료
+    FAIL        // 업로드 실패
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/entity/Notification.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/entity/Notification.java
@@ -1,0 +1,32 @@
+package com.sprint.mission.discodeit.entity;
+
+import com.sprint.mission.discodeit.entity.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+  @Column(nullable = false)
+  private UUID receiverId;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  public Notification(UUID receiverId, String title, String content) {
+    this.receiverId = receiverId;
+    this.title = title;
+    this.content = content;
+  }
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
@@ -32,11 +32,18 @@ public class ReadStatus extends BaseUpdatableEntity {
   private Channel channel;
   @Column(columnDefinition = "timestamp with time zone", nullable = false)
   private Instant lastReadAt;
+  @Column(nullable = false)
+  private boolean notificationEnabled;
 
   public ReadStatus(User user, Channel channel, Instant lastReadAt) {
     this.user = user;
     this.channel = channel;
     this.lastReadAt = lastReadAt;
+    if (channel.getType().equals(ChannelType.PRIVATE)) {
+      this.notificationEnabled = true;
+    } else {
+      this.notificationEnabled = false;
+    }
   }
 
   public void update(Instant newLastReadAt) {

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/event/BinaryContentCreatedEvent.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/event/BinaryContentCreatedEvent.java
@@ -1,0 +1,16 @@
+package com.sprint.mission.discodeit.event;
+
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record BinaryContentCreatedEvent(
+    UUID binaryContentId,     // DB에 저장된 BinaryContent PK
+    byte[] data,              // 저장할 실제 바이너리
+    String contentType,       // MIME 타입
+    String originalFilename,  // 원본 파일명
+    Long size                 // 바이트 크기
+) {
+
+}
+

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/event/MessageCreatedEvent.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/event/MessageCreatedEvent.java
@@ -1,0 +1,18 @@
+package com.sprint.mission.discodeit.event;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record MessageCreatedEvent(
+    UUID messageId,           // DB에 저장된 Message PK
+    UUID channelId,           // 메시지가 속한 채널 ID
+    UUID authorId,            // 메시지 작성자 ID
+    String content,           // 메시지 내용
+    Instant createdAt,        // 메시지 생성 시각
+    List<UUID> attachmentIds  // 첨부파일 ID 목록
+) {
+
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/event/RoleUpdatedEvent.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/event/RoleUpdatedEvent.java
@@ -1,0 +1,16 @@
+package com.sprint.mission.discodeit.event;
+
+import com.sprint.mission.discodeit.entity.Role;
+import java.time.Instant;
+import java.util.UUID;
+
+public record RoleUpdatedEvent(
+    UUID userId,           // 권한이 변경된 사용자 ID
+    String username,       // 사용자명 (로그/알림용)
+    String email,          // 이메일 (알림용)
+    Role previousRole,     // 이전 권한
+    Role newRole,          // 새로운 권한
+    Instant updatedAt      // 권한 변경 시각
+) {
+
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/event/S3UploadFailedEvent.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/event/S3UploadFailedEvent.java
@@ -1,0 +1,20 @@
+package com.sprint.mission.discodeit.event;
+
+import com.sprint.mission.discodeit.config.MDCLoggingInterceptor;
+import java.util.UUID;
+import lombok.Getter;
+import org.slf4j.MDC;
+
+@Getter
+public class S3UploadFailedEvent {
+
+  private final UUID binaryContentId;
+  private final Throwable e;
+  private final String requestId;
+
+  public S3UploadFailedEvent(UUID binaryContentId, Throwable e) {
+    this.binaryContentId = binaryContentId;
+    this.e = e;
+    this.requestId = MDC.get(MDCLoggingInterceptor.REQUEST_ID);
+  }
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/exception/ErrorCode.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/exception/ErrorCode.java
@@ -4,36 +4,39 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
-    // User 관련 에러 코드
-    USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
-    DUPLICATE_USER("이미 존재하는 사용자입니다."),
-    INVALID_USER_CREDENTIALS("잘못된 사용자 인증 정보입니다."),
+  // User 관련 에러 코드
+  USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
+  DUPLICATE_USER("이미 존재하는 사용자입니다."),
+  INVALID_USER_CREDENTIALS("잘못된 사용자 인증 정보입니다."),
 
-    // Channel 관련 에러 코드
-    CHANNEL_NOT_FOUND("채널을 찾을 수 없습니다."),
-    PRIVATE_CHANNEL_UPDATE("비공개 채널은 수정할 수 없습니다."),
+  // Channel 관련 에러 코드
+  CHANNEL_NOT_FOUND("채널을 찾을 수 없습니다."),
+  PRIVATE_CHANNEL_UPDATE("비공개 채널은 수정할 수 없습니다."),
 
-    // Message 관련 에러 코드
-    MESSAGE_NOT_FOUND("메시지를 찾을 수 없습니다."),
+  // Message 관련 에러 코드
+  MESSAGE_NOT_FOUND("메시지를 찾을 수 없습니다."),
 
-    // BinaryContent 관련 에러 코드
-    BINARY_CONTENT_NOT_FOUND("바이너리 컨텐츠를 찾을 수 없습니다."),
+  // BinaryContent 관련 에러 코드
+  BINARY_CONTENT_NOT_FOUND("바이너리 컨텐츠를 찾을 수 없습니다."),
 
-    // ReadStatus 관련 에러 코드
-    READ_STATUS_NOT_FOUND("읽음 상태를 찾을 수 없습니다."),
-    DUPLICATE_READ_STATUS("이미 존재하는 읽음 상태입니다."),
+  // ReadStatus 관련 에러 코드
+  READ_STATUS_NOT_FOUND("읽음 상태를 찾을 수 없습니다."),
+  DUPLICATE_READ_STATUS("이미 존재하는 읽음 상태입니다."),
 
-    // Server 에러 코드
-    INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다."),
-    INVALID_REQUEST("잘못된 요청입니다."),
+  // Notification 관련 에러 코드
+  NOTIFICATION_NOT_FOUND("알림을 찾을 수 없습니다."),
 
-    // Security 관련 에러 코드
-    INVALID_TOKEN("토큰이 유효하지 않습니다."),
-    INVALID_USER_DETAILS("사용자 인증 정보(UserDetails)가 유효하지 않습니다.");
+  // Server 에러 코드
+  INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다."),
+  INVALID_REQUEST("잘못된 요청입니다."),
 
-    private final String message;
+  // Security 관련 에러 코드
+  INVALID_TOKEN("토큰이 유효하지 않습니다."),
+  INVALID_USER_DETAILS("사용자 인증 정보(UserDetails)가 유효하지 않습니다.");
 
-    ErrorCode(String message) {
-        this.message = message;
-    }
+  private final String message;
+
+  ErrorCode(String message) {
+    this.message = message;
+  }
 } 

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/exception/notification/NotificationException.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/exception/notification/NotificationException.java
@@ -1,0 +1,14 @@
+package com.sprint.mission.discodeit.exception.notification;
+
+import com.sprint.mission.discodeit.exception.DiscodeitException;
+import com.sprint.mission.discodeit.exception.ErrorCode;
+
+public class NotificationException extends DiscodeitException {
+    public NotificationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public NotificationException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/exception/notification/NotificationNotFoundException.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/exception/notification/NotificationNotFoundException.java
@@ -1,0 +1,17 @@
+package com.sprint.mission.discodeit.exception.notification;
+
+import com.sprint.mission.discodeit.exception.ErrorCode;
+
+import java.util.UUID;
+
+public class NotificationNotFoundException extends NotificationException {
+    public NotificationNotFoundException() {
+        super(ErrorCode.NOTIFICATION_NOT_FOUND);
+    }
+    
+    public static NotificationNotFoundException withId(UUID notificationId) {
+        NotificationNotFoundException exception = new NotificationNotFoundException();
+        exception.addDetail("notificationId", notificationId);
+        return exception;
+    }
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/handler/BinaryContentCreatedEventListener.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/handler/BinaryContentCreatedEventListener.java
@@ -1,0 +1,63 @@
+package com.sprint.mission.discodeit.handler;
+
+import com.sprint.mission.discodeit.entity.BinaryContentStatus;
+import com.sprint.mission.discodeit.event.BinaryContentCreatedEvent;
+import com.sprint.mission.discodeit.repository.BinaryContentRepository;
+import com.sprint.mission.discodeit.storage.BinaryContentStorage;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BinaryContentCreatedEventListener {
+
+  private final BinaryContentStorage storage;
+  private final BinaryContentRepository binaryContentRepository;
+
+  @Async("eventTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handle(BinaryContentCreatedEvent event) {
+    runWithStatusUpdate(
+        event.binaryContentId(),
+        () -> {
+          storage.put(event.binaryContentId(), event.data());
+          log.info("Binary content 저장. id={}, size={}, contentType={}, filename={}",
+              event.binaryContentId(), event.size(), event.contentType(), event.originalFilename());
+        }
+    );
+  }
+
+  private void runWithStatusUpdate(UUID contentId, Runnable action) {
+    try {
+      action.run();
+      markStatus(contentId, BinaryContentStatus.SUCCESS);
+    } catch (Exception e) {
+      log.error("Binary content 저장 실패. id={}", contentId, e);
+      safelyMarkFail(contentId);
+    }
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  protected void markStatus(UUID contentId, BinaryContentStatus status) {
+    binaryContentRepository.findById(contentId).ifPresent(entity -> {
+      entity.updateStatus(status);
+      binaryContentRepository.save(entity);
+    });
+  }
+
+  private void safelyMarkFail(UUID contentId) {
+    try {
+      markStatus(contentId, BinaryContentStatus.FAIL);
+    } catch (Exception ex) {
+      log.error("FAIL 상태로 설정 실패. id={}", contentId, ex);
+    }
+  }
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/handler/MessageCreatedEventListener.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/handler/MessageCreatedEventListener.java
@@ -1,0 +1,98 @@
+package com.sprint.mission.discodeit.handler;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.event.MessageCreatedEvent;
+import com.sprint.mission.discodeit.event.RoleUpdatedEvent;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.repository.ReadStatusRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.service.NotificationService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MessageCreatedEventListener {
+
+  private final NotificationService notificationService;
+  private final ChannelRepository channelRepository;
+  private final UserRepository userRepository;
+  private final ReadStatusRepository readStatusRepository;
+
+  @Async("eventTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void on(MessageCreatedEvent event) {
+    try {
+      log.info("새로운 message에 대한 알림 생성. messageId={}, channelId={}",
+          event.messageId(), event.channelId());
+
+      // 1. 해당 채널의 알림 여부를 활성화한 ReadStatus 조회
+      List<ReadStatus> notificationEnabledReadStatuses = readStatusRepository
+          .findByChannelIdAndNotificationEnabledTrue(event.channelId());
+
+      // 2. 메시지 작성자와 채널 정보 조회
+      User author = userRepository.findById(event.authorId())
+          .orElseThrow(() -> new RuntimeException("Author not found: " + event.authorId()));
+
+      Channel channel = channelRepository.findById(event.channelId())
+          .orElseThrow(() -> new RuntimeException("Channel not found: " + event.channelId()));
+
+      // 3. 알림 생성 (메시지 작성자 제외)
+      for (ReadStatus readStatus : notificationEnabledReadStatuses) {
+        UUID receiverId = readStatus.getUser().getId();
+
+        // 메시지 작성자는 알림 대상에서 제외
+        if (!receiverId.equals(event.authorId())) {
+          String title = String.format("%s (#%s)", author.getUsername(), channel.getName());
+          String content = event.content();
+
+          notificationService.create(receiverId, title, content);
+
+          log.debug("Message 알림 생성됨. receiverId={}, messageId={}",
+              receiverId, event.messageId());
+        }
+      }
+
+      log.info("Message 알림 생성 성공. messageId={}, recipientCount={}",
+          event.messageId(),
+          notificationEnabledReadStatuses.size() -
+              (notificationEnabledReadStatuses.stream()
+                  .anyMatch(rs -> rs.getUser().getId().equals(event.authorId())) ? 1 : 0));
+
+    } catch (Exception e) {
+      log.error("Message 알림 생성 실패. messageId={}",
+          event.messageId(), e);
+    }
+  }
+
+  @Async("eventTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void on(RoleUpdatedEvent event) {
+    try {
+      log.info("권한 변경 알림 생성. userId={}, previousRole={}, newRole={}",
+          event.userId(), event.previousRole(), event.newRole());
+
+      // 권한이 변경된 당사자에게 알림 생성
+      String title = "권한이 변경되었습니다.";
+      String content = String.format("%s -> %s", event.previousRole(), event.newRole());
+
+      notificationService.create(event.userId(), title, content);
+
+      log.info("권한 변경 알림 생성 성공. userId={}", event.userId());
+
+    } catch (Exception e) {
+      log.error("권한 변경 알림 생성 실패. userId={}",
+          event.userId(), e);
+    }
+  }
+
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/handler/NotificationRequiredEventListener.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/handler/NotificationRequiredEventListener.java
@@ -1,0 +1,46 @@
+package com.sprint.mission.discodeit.handler;
+
+import com.sprint.mission.discodeit.event.S3UploadFailedEvent;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.service.NotificationService;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationRequiredEventListener {
+
+  private final UserRepository userRepository;
+  private final NotificationService notificationService;
+
+  @Value("${discodeit.admin.username}")
+  private String adminUsername;
+
+  @Async("eventTaskExecutor")
+  @EventListener
+  public void on(S3UploadFailedEvent event) {
+    String requestId = event.getRequestId();
+    UUID binaryContentId = event.getBinaryContentId();
+    Throwable e = event.getE();
+
+    String title = "S3 파일 업로드 실패";
+
+    StringBuffer sb = new StringBuffer();
+    sb.append("RequestId: ").append(requestId).append("\n");
+    sb.append("BinaryContentId: ").append(binaryContentId).append("\n");
+    sb.append("Error: ").append(e.getMessage()).append("\n");
+    String content = sb.toString();
+
+    Set<UUID> receiverIds = userRepository.findByUsername(adminUsername)
+        .map(user -> Set.of(user.getId()))
+        .orElse(Set.of());
+
+    notificationService.create(receiverIds, title, content);
+  }
+
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/mapper/NotificationMapper.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/mapper/NotificationMapper.java
@@ -1,0 +1,16 @@
+package com.sprint.mission.discodeit.mapper;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.entity.Notification;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface NotificationMapper {
+    
+    @Mapping(target = "receivedId", source = "receiverId")
+    NotificationDto toDto(Notification notification);
+    
+    @Mapping(target = "receiverId", source = "receivedId")
+    Notification toEntity(NotificationDto notificationDto);
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/repository/NotificationRepository.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/repository/NotificationRepository.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+    
+    List<Notification> findByReceiverIdOrderByCreatedAtDesc(UUID receiverId);
+    
+    Optional<Notification> findByIdAndReceiverId(UUID id, UUID receiverId);
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/repository/ReadStatusRepository.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/repository/ReadStatusRepository.java
@@ -1,25 +1,26 @@
 package com.sprint.mission.discodeit.repository;
 
 import com.sprint.mission.discodeit.entity.ReadStatus;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-import java.util.UUID;
-
 public interface ReadStatusRepository extends JpaRepository<ReadStatus, UUID> {
 
 
-    List<ReadStatus> findAllByUserId(UUID userId);
+  List<ReadStatus> findAllByUserId(UUID userId);
 
-    @Query("SELECT r FROM ReadStatus r "
-            + "JOIN FETCH r.user u "
-            + "LEFT JOIN FETCH u.profile "
-            + "WHERE r.channel.id = :channelId")
-    List<ReadStatus> findAllByChannelIdWithUser(@Param("channelId") UUID channelId);
+  @Query("SELECT r FROM ReadStatus r "
+      + "JOIN FETCH r.user u "
+      + "LEFT JOIN FETCH u.profile "
+      + "WHERE r.channel.id = :channelId")
+  List<ReadStatus> findAllByChannelIdWithUser(@Param("channelId") UUID channelId);
 
-    Boolean existsByUserIdAndChannelId(UUID userId, UUID channelId);
+  Boolean existsByUserIdAndChannelId(UUID userId, UUID channelId);
 
-    void deleteAllByChannelId(UUID channelId);
+  void deleteAllByChannelId(UUID channelId);
+
+  List<ReadStatus> findByChannelIdAndNotificationEnabledTrue(UUID uuid);
 }

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/service/NotificationService.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/service/NotificationService.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+public interface NotificationService {
+
+  List<NotificationDto> findAllByReceiverId(UUID receiverId);
+
+  void deleteByIdAndReceiverId(UUID notificationId, UUID receiverId);
+
+  void create(Set<UUID> receiverId, String title, String content);
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
@@ -3,78 +3,90 @@ package com.sprint.mission.discodeit.service.basic;
 import com.sprint.mission.discodeit.dto.data.BinaryContentDto;
 import com.sprint.mission.discodeit.dto.request.BinaryContentCreateRequest;
 import com.sprint.mission.discodeit.entity.BinaryContent;
+import com.sprint.mission.discodeit.event.BinaryContentCreatedEvent;
 import com.sprint.mission.discodeit.exception.binarycontent.BinaryContentNotFoundException;
 import com.sprint.mission.discodeit.mapper.BinaryContentMapper;
 import com.sprint.mission.discodeit.repository.BinaryContentRepository;
 import com.sprint.mission.discodeit.service.BinaryContentService;
 import com.sprint.mission.discodeit.storage.BinaryContentStorage;
-import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class BasicBinaryContentService implements BinaryContentService {
 
-  private final BinaryContentRepository binaryContentRepository;
-  private final BinaryContentMapper binaryContentMapper;
-  private final BinaryContentStorage binaryContentStorage;
+    private final BinaryContentRepository binaryContentRepository;
+    private final BinaryContentMapper binaryContentMapper;
+    private final BinaryContentStorage binaryContentStorage;
+    private final ApplicationEventPublisher eventPublisher;
 
-  @Transactional
-  @Override
-  public BinaryContentDto create(BinaryContentCreateRequest request) {
-    log.debug("바이너리 컨텐츠 생성 시작: fileName={}, size={}, contentType={}", 
-        request.fileName(), request.bytes().length, request.contentType());
+    @Transactional
+    @Override
+    public BinaryContentDto create(BinaryContentCreateRequest request) {
+        log.debug("바이너리 컨텐츠 생성 시작: fileName={}, size={}, contentType={}",
+                request.fileName(), request.bytes().length, request.contentType());
 
-    String fileName = request.fileName();
-    byte[] bytes = request.bytes();
-    String contentType = request.contentType();
-    BinaryContent binaryContent = new BinaryContent(
-        fileName,
-        (long) bytes.length,
-        contentType
-    );
-    binaryContentRepository.save(binaryContent);
-    binaryContentStorage.put(binaryContent.getId(), bytes);
+        String fileName = request.fileName();
+        byte[] bytes = request.bytes();
+        String contentType = request.contentType();
+        BinaryContent binaryContent = new BinaryContent(
+                fileName,
+                (long) bytes.length,
+                contentType
+        );
+        BinaryContent savedContent = binaryContentRepository.save(binaryContent);
+        eventPublisher.publishEvent(
+                BinaryContentCreatedEvent.builder()
+                        .binaryContentId(savedContent.getId())
+                        .data(bytes)                    // 업로드 받은 byte[]
+                        .contentType(contentType)       // MIME
+                        .originalFilename(fileName)
+                        .size((long) bytes.length)
+                        .build()
+        );
 
-    log.info("바이너리 컨텐츠 생성 완료: id={}, fileName={}, size={}", 
-        binaryContent.getId(), fileName, bytes.length);
-    return binaryContentMapper.toDto(binaryContent);
-  }
-
-  @Override
-  public BinaryContentDto find(UUID binaryContentId) {
-    log.debug("바이너리 컨텐츠 조회 시작: id={}", binaryContentId);
-    BinaryContentDto dto = binaryContentRepository.findById(binaryContentId)
-        .map(binaryContentMapper::toDto)
-        .orElseThrow(() -> BinaryContentNotFoundException.withId(binaryContentId));
-    log.info("바이너리 컨텐츠 조회 완료: id={}, fileName={}", 
-        dto.id(), dto.fileName());
-    return dto;
-  }
-
-  @Override
-  public List<BinaryContentDto> findAllByIdIn(List<UUID> binaryContentIds) {
-    log.debug("바이너리 컨텐츠 목록 조회 시작: ids={}", binaryContentIds);
-    List<BinaryContentDto> dtos = binaryContentRepository.findAllById(binaryContentIds).stream()
-        .map(binaryContentMapper::toDto)
-        .toList();
-    log.info("바이너리 컨텐츠 목록 조회 완료: 조회된 항목 수={}", dtos.size());
-    return dtos;
-  }
-
-  @Transactional
-  @Override
-  public void delete(UUID binaryContentId) {
-    log.debug("바이너리 컨텐츠 삭제 시작: id={}", binaryContentId);
-    if (!binaryContentRepository.existsById(binaryContentId)) {
-      throw BinaryContentNotFoundException.withId(binaryContentId);
+        log.info("바이너리 컨텐츠 생성 완료: id={}, fileName={}, size={}",
+                savedContent.getId(), fileName, bytes.length);
+        return binaryContentMapper.toDto(savedContent);
     }
-    binaryContentRepository.deleteById(binaryContentId);
-    log.info("바이너리 컨텐츠 삭제 완료: id={}", binaryContentId);
-  }
+
+    @Override
+    public BinaryContentDto find(UUID binaryContentId) {
+        log.debug("바이너리 컨텐츠 조회 시작: id={}", binaryContentId);
+        BinaryContentDto dto = binaryContentRepository.findById(binaryContentId)
+                .map(binaryContentMapper::toDto)
+                .orElseThrow(() -> BinaryContentNotFoundException.withId(binaryContentId));
+        log.info("바이너리 컨텐츠 조회 완료: id={}, fileName={}",
+                dto.id(), dto.fileName());
+        return dto;
+    }
+
+    @Override
+    public List<BinaryContentDto> findAllByIdIn(List<UUID> binaryContentIds) {
+        log.debug("바이너리 컨텐츠 목록 조회 시작: ids={}", binaryContentIds);
+        List<BinaryContentDto> dtos = binaryContentRepository.findAllById(binaryContentIds).stream()
+                .map(binaryContentMapper::toDto)
+                .toList();
+        log.info("바이너리 컨텐츠 목록 조회 완료: 조회된 항목 수={}", dtos.size());
+        return dtos;
+    }
+
+    @Transactional
+    @Override
+    public void delete(UUID binaryContentId) {
+        log.debug("바이너리 컨텐츠 삭제 시작: id={}", binaryContentId);
+        if (!binaryContentRepository.existsById(binaryContentId)) {
+            throw BinaryContentNotFoundException.withId(binaryContentId);
+        }
+        binaryContentRepository.deleteById(binaryContentId);
+        log.info("바이너리 컨텐츠 삭제 완료: id={}", binaryContentId);
+    }
 }

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
@@ -9,6 +9,8 @@ import com.sprint.mission.discodeit.entity.BinaryContent;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.Message;
 import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.event.BinaryContentCreatedEvent;
+import com.sprint.mission.discodeit.event.MessageCreatedEvent;
 import com.sprint.mission.discodeit.exception.channel.ChannelNotFoundException;
 import com.sprint.mission.discodeit.exception.message.MessageNotFoundException;
 import com.sprint.mission.discodeit.exception.user.UserNotFoundException;
@@ -20,126 +22,148 @@ import com.sprint.mission.discodeit.repository.MessageRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.service.MessageService;
 import com.sprint.mission.discodeit.storage.BinaryContentStorage;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class BasicMessageService implements MessageService {
 
-    private final MessageRepository messageRepository;
-    private final ChannelRepository channelRepository;
-    private final UserRepository userRepository;
-    private final MessageMapper messageMapper;
-    private final BinaryContentStorage binaryContentStorage;
-    private final BinaryContentRepository binaryContentRepository;
-    private final PageResponseMapper pageResponseMapper;
+  private final MessageRepository messageRepository;
+  private final ChannelRepository channelRepository;
+  private final UserRepository userRepository;
+  private final MessageMapper messageMapper;
+  private final BinaryContentStorage binaryContentStorage;
+  private final BinaryContentRepository binaryContentRepository;
+  private final PageResponseMapper pageResponseMapper;
+  private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional
-    @Override
-    public MessageDto create(MessageCreateRequest messageCreateRequest,
-                             List<BinaryContentCreateRequest> binaryContentCreateRequests) {
-        log.debug("메시지 생성 시작: request={}", messageCreateRequest);
-        UUID channelId = messageCreateRequest.channelId();
-        UUID authorId = messageCreateRequest.authorId();
+  @Transactional
+  @Override
+  public MessageDto create(MessageCreateRequest messageCreateRequest,
+      List<BinaryContentCreateRequest> binaryContentCreateRequests) {
+    log.debug("메시지 생성 시작: request={}", messageCreateRequest);
+    UUID channelId = messageCreateRequest.channelId();
+    UUID authorId = messageCreateRequest.authorId();
 
-        Channel channel = channelRepository.findById(channelId)
-                .orElseThrow(() -> ChannelNotFoundException.withId(channelId));
-        User author = userRepository.findById(authorId)
-                .orElseThrow(() -> UserNotFoundException.withId(authorId));
+    Channel channel = channelRepository.findById(channelId)
+        .orElseThrow(() -> ChannelNotFoundException.withId(channelId));
+    User author = userRepository.findById(authorId)
+        .orElseThrow(() -> UserNotFoundException.withId(authorId));
 
-        List<BinaryContent> attachments = binaryContentCreateRequests.stream()
-                .map(attachmentRequest -> {
-                    String fileName = attachmentRequest.fileName();
-                    String contentType = attachmentRequest.contentType();
-                    byte[] bytes = attachmentRequest.bytes();
+    List<BinaryContent> attachments = binaryContentCreateRequests.stream()
+        .map(attachmentRequest -> {
+          String fileName = attachmentRequest.fileName();
+          String contentType = attachmentRequest.contentType();
+          byte[] bytes = attachmentRequest.bytes();
 
-                    BinaryContent binaryContent = new BinaryContent(fileName, (long) bytes.length,
-                            contentType);
-                    binaryContentRepository.save(binaryContent);
-                    binaryContentStorage.put(binaryContent.getId(), bytes);
-                    return binaryContent;
-                })
-                .toList();
+          BinaryContent binaryContent = new BinaryContent(fileName, (long) bytes.length,
+              contentType);
+          BinaryContent savedContent = binaryContentRepository.save(binaryContent);
+          eventPublisher.publishEvent(
+              BinaryContentCreatedEvent.builder()
+                  .binaryContentId(savedContent.getId())
+                  .data(bytes)                    // 업로드 받은 byte[]
+                  .contentType(contentType)       // MIME
+                  .originalFilename(fileName)
+                  .size((long) bytes.length)
+                  .build()
+          );
 
-        String content = messageCreateRequest.content();
-        Message message = new Message(
-                content,
-                channel,
-                author,
-                attachments
-        );
+          return savedContent;
+        })
+        .toList();
 
-        messageRepository.save(message);
-        log.info("메시지 생성 완료: id={}, channelId={}", message.getId(), channelId);
-        return messageMapper.toDto(message);
+    String content = messageCreateRequest.content();
+    Message message = new Message(
+        content,
+        channel,
+        author,
+        attachments
+    );
+
+    messageRepository.save(message);
+    // MessageCreated 이벤트 발행
+    eventPublisher.publishEvent(
+        MessageCreatedEvent.builder()
+            .messageId(message.getId())
+            .channelId(message.getChannel().getId())
+            .authorId(message.getAuthor().getId())
+            .content(message.getContent())
+            .createdAt(message.getCreatedAt())
+            .attachmentIds(attachments.stream().map(BinaryContent::getId).toList())
+            .build()
+    );
+    log.info("메시지 생성 완료: id={}, channelId={}", message.getId(), channelId);
+
+    return messageMapper.toDto(message);
+  }
+
+  @Transactional(readOnly = true)
+  @Override
+  public MessageDto find(UUID messageId) {
+    return messageRepository.findById(messageId)
+        .map(messageMapper::toDto)
+        .orElseThrow(() -> MessageNotFoundException.withId(messageId));
+  }
+
+  @Transactional(readOnly = true)
+  @Override
+  public PageResponse<MessageDto> findAllByChannelId(UUID channelId, Instant createAt,
+      Pageable pageable) {
+    Slice<MessageDto> slice = messageRepository.findAllByChannelIdWithAuthor(channelId,
+            Optional.ofNullable(createAt).orElse(Instant.now()),
+            pageable)
+        .map(messageMapper::toDto);
+
+    Instant nextCursor = null;
+    if (!slice.getContent().isEmpty()) {
+      nextCursor = slice.getContent().get(slice.getContent().size() - 1)
+          .createdAt();
     }
 
-    @Transactional(readOnly = true)
-    @Override
-    public MessageDto find(UUID messageId) {
-        return messageRepository.findById(messageId)
-                .map(messageMapper::toDto)
-                .orElseThrow(() -> MessageNotFoundException.withId(messageId));
+    return pageResponseMapper.fromSlice(slice, nextCursor);
+  }
+
+  public boolean isAuthor(UUID messageId, UUID userId) {
+    return messageRepository.findById(messageId)
+        .map(m -> m.getAuthor().getId().equals(userId))
+        .orElse(false);
+  }
+
+  @Transactional
+  @Override
+  @PreAuthorize("@messageService.isAuthor(#messageId, principal.userDto.id)")
+  public MessageDto update(UUID messageId, MessageUpdateRequest request) {
+    log.debug("메시지 수정 시작: id={}, request={}", messageId, request);
+    Message message = messageRepository.findById(messageId)
+        .orElseThrow(() -> MessageNotFoundException.withId(messageId));
+
+    message.update(request.newContent());
+    log.info("메시지 수정 완료: id={}, channelId={}", messageId, message.getChannel().getId());
+    return messageMapper.toDto(message);
+  }
+
+  @Transactional
+  @Override
+  @PreAuthorize("@messageService.isAuthor(#messageId, principal.userDto.id)")
+  public void delete(UUID messageId) {
+    log.debug("메시지 삭제 시작: id={}", messageId);
+    if (!messageRepository.existsById(messageId)) {
+      throw MessageNotFoundException.withId(messageId);
     }
-
-    @Transactional(readOnly = true)
-    @Override
-    public PageResponse<MessageDto> findAllByChannelId(UUID channelId, Instant createAt,
-                                                       Pageable pageable) {
-        Slice<MessageDto> slice = messageRepository.findAllByChannelIdWithAuthor(channelId,
-                        Optional.ofNullable(createAt).orElse(Instant.now()),
-                        pageable)
-                .map(messageMapper::toDto);
-
-        Instant nextCursor = null;
-        if (!slice.getContent().isEmpty()) {
-            nextCursor = slice.getContent().get(slice.getContent().size() - 1)
-                    .createdAt();
-        }
-
-        return pageResponseMapper.fromSlice(slice, nextCursor);
-    }
-
-    public boolean isAuthor(UUID messageId, UUID userId) {
-        return messageRepository.findById(messageId)
-                .map(m -> m.getAuthor().getId().equals(userId))
-                .orElse(false);
-    }
-
-    @Transactional
-    @Override
-    @PreAuthorize("@messageService.isAuthor(#messageId, principal.userDto.id)")
-    public MessageDto update(UUID messageId, MessageUpdateRequest request) {
-        log.debug("메시지 수정 시작: id={}, request={}", messageId, request);
-        Message message = messageRepository.findById(messageId)
-                .orElseThrow(() -> MessageNotFoundException.withId(messageId));
-
-        message.update(request.newContent());
-        log.info("메시지 수정 완료: id={}, channelId={}", messageId, message.getChannel().getId());
-        return messageMapper.toDto(message);
-    }
-
-    @Transactional
-    @Override
-    @PreAuthorize("@messageService.isAuthor(#messageId, principal.userDto.id)")
-    public void delete(UUID messageId) {
-        log.debug("메시지 삭제 시작: id={}", messageId);
-        if (!messageRepository.existsById(messageId)) {
-            throw MessageNotFoundException.withId(messageId);
-        }
-        messageRepository.deleteById(messageId);
-        log.info("메시지 삭제 완료: id={}", messageId);
-    }
+    messageRepository.deleteById(messageId);
+    log.info("메시지 삭제 완료: id={}", messageId);
+  }
 }

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/service/basic/BasicNotificationService.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/service/basic/BasicNotificationService.java
@@ -1,0 +1,55 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.exception.notification.NotificationNotFoundException;
+import com.sprint.mission.discodeit.mapper.NotificationMapper;
+import com.sprint.mission.discodeit.repository.NotificationRepository;
+import com.sprint.mission.discodeit.service.NotificationService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BasicNotificationService implements NotificationService {
+
+  private final NotificationRepository notificationRepository;
+  private final NotificationMapper notificationMapper;
+
+  @Transactional(readOnly = true)
+  @Override
+  public List<NotificationDto> findAllByReceiverId(UUID receiverId) {
+    log.debug("알림 목록 조회 시작: receiverId={}", receiverId);
+
+    List<NotificationDto> notifications = notificationRepository
+        .findByReceiverIdOrderByCreatedAtDesc(receiverId)
+        .stream()
+        .map(notificationMapper::toDto)
+        .toList();
+
+    log.info("알림 목록 조회 완료: receiverId={}, count={}", receiverId, notifications.size());
+    return notifications;
+  }
+
+  @Transactional
+  @Override
+  public void deleteByIdAndReceiverId(UUID notificationId, UUID receiverId) {
+    log.debug("알림 삭제 시작: notificationId={}, receiverId={}", notificationId, receiverId);
+
+    var notification = notificationRepository.findByIdAndReceiverId(notificationId, receiverId)
+        .orElseThrow(() -> NotificationNotFoundException.withId(notificationId));
+
+    notificationRepository.delete(notification);
+    log.info("알림 삭제 완료: notificationId={}", notificationId);
+  }
+
+  // BasicNotificationService에 추가
+  public boolean isNotificationOwner(UUID notificationId, UUID userId) {
+    return notificationRepository.findByIdAndReceiverId(notificationId, userId)
+        .isPresent();
+  }
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
@@ -6,15 +6,16 @@ import com.sprint.mission.discodeit.dto.request.UserCreateRequest;
 import com.sprint.mission.discodeit.dto.request.UserUpdateRequest;
 import com.sprint.mission.discodeit.entity.BinaryContent;
 import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.event.BinaryContentCreatedEvent;
 import com.sprint.mission.discodeit.exception.user.UserAlreadyExistsException;
 import com.sprint.mission.discodeit.exception.user.UserNotFoundException;
 import com.sprint.mission.discodeit.mapper.UserMapper;
 import com.sprint.mission.discodeit.repository.BinaryContentRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.service.UserService;
-import com.sprint.mission.discodeit.storage.BinaryContentStorage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -33,8 +34,8 @@ public class BasicUserService implements UserService {
     private final UserRepository userRepository;
     private final UserMapper userMapper;
     private final BinaryContentRepository binaryContentRepository;
-    private final BinaryContentStorage binaryContentStorage;
     private final PasswordEncoder passwordEncoder;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     @Override
@@ -63,9 +64,18 @@ public class BasicUserService implements UserService {
                     byte[] bytes = profileRequest.bytes();
                     BinaryContent binaryContent = new BinaryContent(fileName, (long) bytes.length,
                             contentType);
-                    binaryContentRepository.save(binaryContent);
-                    binaryContentStorage.put(binaryContent.getId(), bytes);
-                    return binaryContent;
+                    BinaryContent savedContent = binaryContentRepository.save(binaryContent);
+                    eventPublisher.publishEvent(
+                            BinaryContentCreatedEvent.builder()
+                                    .binaryContentId(savedContent.getId())
+                                    .data(bytes)                    // 업로드 받은 byte[]
+                                    .contentType(contentType)       // MIME
+                                    .originalFilename(fileName)
+                                    .size((long) bytes.length)
+                                    .build()
+                    );
+
+                    return savedContent;
                 })
                 .orElse(null);
 
@@ -135,9 +145,18 @@ public class BasicUserService implements UserService {
                     byte[] bytes = profileRequest.bytes();
                     BinaryContent binaryContent = new BinaryContent(fileName, (long) bytes.length,
                             contentType);
-                    binaryContentRepository.save(binaryContent);
-                    binaryContentStorage.put(binaryContent.getId(), bytes);
-                    return binaryContent;
+                    BinaryContent savedContent = binaryContentRepository.save(binaryContent);
+                    eventPublisher.publishEvent(
+                            BinaryContentCreatedEvent.builder()
+                                    .binaryContentId(savedContent.getId())
+                                    .data(bytes)                    // 업로드 받은 byte[]
+                                    .contentType(contentType)       // MIME
+                                    .originalFilename(fileName)
+                                    .size((long) bytes.length)
+                                    .build()
+                    );
+
+                    return savedContent;
                 })
                 .orElse(null);
 

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/storage/BinaryContentStorage.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/storage/BinaryContentStorage.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.storage;
+
+import com.sprint.mission.discodeit.dto.data.BinaryContentDto;
+import java.io.InputStream;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+
+public interface BinaryContentStorage {
+
+  UUID put(UUID binaryContentId, byte[] bytes);
+
+  InputStream get(UUID binaryContentId);
+
+  ResponseEntity<?> download(BinaryContentDto metaData);
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/storage/local/LocalBinaryContentStorage.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/storage/local/LocalBinaryContentStorage.java
@@ -1,0 +1,95 @@
+package com.sprint.mission.discodeit.storage.local;
+
+import com.sprint.mission.discodeit.dto.data.BinaryContentDto;
+import com.sprint.mission.discodeit.storage.BinaryContentStorage;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@ConditionalOnProperty(name = "discodeit.storage.type", havingValue = "local")
+@Component
+public class LocalBinaryContentStorage implements BinaryContentStorage {
+
+  private final Path root;
+
+  public LocalBinaryContentStorage(
+      @Value("${discodeit.storage.local.root-path}") Path root
+  ) {
+    this.root = root;
+  }
+
+  @PostConstruct
+  public void init() {
+    if (!Files.exists(root)) {
+      try {
+        Files.createDirectories(root);
+      } catch (IOException e) {
+        e.printStackTrace();
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public UUID put(UUID binaryContentId, byte[] bytes) {
+    try {
+      Thread.sleep(3000);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Thread interrupted while simulating delay", e);
+    }
+    Path filePath = resolvePath(binaryContentId);
+    if (Files.exists(filePath)) {
+      throw new IllegalArgumentException("File with key " + binaryContentId + " already exists");
+    }
+    try (OutputStream outputStream = Files.newOutputStream(filePath)) {
+      outputStream.write(bytes);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return binaryContentId;
+  }
+
+  public InputStream get(UUID binaryContentId) {
+    Path filePath = resolvePath(binaryContentId);
+    if (Files.notExists(filePath)) {
+      throw new NoSuchElementException("File with key " + binaryContentId + " does not exist");
+    }
+    try {
+      return Files.newInputStream(filePath);
+    } catch (IOException e) {
+      e.printStackTrace();
+      throw new RuntimeException(e);
+    }
+  }
+
+  private Path resolvePath(UUID key) {
+    return root.resolve(key.toString());
+  }
+
+  @Override
+  public ResponseEntity<Resource> download(BinaryContentDto metaData) {
+    InputStream inputStream = get(metaData.id());
+    Resource resource = new InputStreamResource(inputStream);
+
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .header(HttpHeaders.CONTENT_DISPOSITION,
+            "attachment; filename=\"" + metaData.fileName() + "\"")
+        .header(HttpHeaders.CONTENT_TYPE, metaData.contentType())
+        .header(HttpHeaders.CONTENT_LENGTH, String.valueOf(metaData.size()))
+        .body(resource);
+  }
+}

--- a/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/storage/s3/S3BinaryContentStorage.java
+++ b/3-sprint-mission/src/main/java/com/sprint/mission/discodeit/storage/s3/S3BinaryContentStorage.java
@@ -1,0 +1,175 @@
+package com.sprint.mission.discodeit.storage.s3;
+
+import com.sprint.mission.discodeit.dto.data.BinaryContentDto;
+import com.sprint.mission.discodeit.event.S3UploadFailedEvent;
+import com.sprint.mission.discodeit.storage.BinaryContentStorage;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+@Slf4j
+@ConditionalOnProperty(name = "discodeit.storage.type", havingValue = "s3")
+@Component
+public class S3BinaryContentStorage implements BinaryContentStorage {
+
+  private final String accessKey;
+  private final String secretKey;
+  private final String region;
+  private final String bucket;
+
+  @Value("${discodeit.storage.s3.presigned-url-expiration:600}") // 기본값 10분
+  private long presignedUrlExpirationSeconds;
+
+  private final ApplicationEventPublisher eventPublisher;
+
+  public S3BinaryContentStorage(
+      @Value("${discodeit.storage.s3.access-key}") String accessKey,
+      @Value("${discodeit.storage.s3.secret-key}") String secretKey,
+      @Value("${discodeit.storage.s3.region}") String region,
+      @Value("${discodeit.storage.s3.bucket}") String bucket,
+      ApplicationEventPublisher eventPublisher
+  ) {
+    this.accessKey = accessKey;
+    this.secretKey = secretKey;
+    this.region = region;
+    this.bucket = bucket;
+    this.eventPublisher = eventPublisher;
+  }
+
+  @Retryable(
+      retryFor = S3Exception.class,
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000, multiplier = 2)
+  )
+  @Override
+  public UUID put(UUID binaryContentId, byte[] bytes) {
+    String key = binaryContentId.toString();
+    try {
+      S3Client s3Client = getS3Client();
+
+      PutObjectRequest request = PutObjectRequest.builder()
+          .bucket(bucket)
+          .key(key)
+          .build();
+
+      s3Client.putObject(request, RequestBody.fromBytes(bytes));
+      log.info("S3에 파일 업로드 성공: {}", key);
+
+      return binaryContentId;
+    } catch (S3Exception e) {
+      log.error("S3에 파일 업로드 실패: {}", e.getMessage());
+      throw new RuntimeException("S3에 파일 업로드 실패: " + key, e);
+    }
+  }
+
+  @Recover
+  public UUID recover(S3Exception e, UUID binaryContentId, byte[] bytes) {
+    log.error("S3 업로드 재시도 실패: {}, key={}", e.getMessage(), binaryContentId);
+    eventPublisher.publishEvent(
+        new S3UploadFailedEvent(binaryContentId, e)
+    );
+
+    throw new RuntimeException(e);
+  }
+
+  @Override
+  public InputStream get(UUID binaryContentId) {
+    String key = binaryContentId.toString();
+    try {
+      S3Client s3Client = getS3Client();
+
+      GetObjectRequest request = GetObjectRequest.builder()
+          .bucket(bucket)
+          .key(key)
+          .build();
+
+      byte[] bytes = s3Client.getObjectAsBytes(request).asByteArray();
+      return new ByteArrayInputStream(bytes);
+    } catch (S3Exception e) {
+      log.error("S3에서 파일 다운로드 실패: {}", e.getMessage());
+      throw new NoSuchElementException("File with key " + key + " does not exist");
+    }
+  }
+
+  private S3Client getS3Client() {
+    return S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(
+            StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)
+            )
+        )
+        .build();
+  }
+
+  @Override
+  public ResponseEntity<Void> download(BinaryContentDto metaData) {
+    try {
+      String key = metaData.id().toString();
+      String presignedUrl = generatePresignedUrl(key, metaData.contentType());
+
+      log.info("생성된 Presigned URL: {}", presignedUrl);
+
+      return ResponseEntity
+          .status(HttpStatus.FOUND)
+          .header(HttpHeaders.LOCATION, presignedUrl)
+          .build();
+    } catch (Exception e) {
+      log.error("Presigned URL 생성 실패: {}", e.getMessage());
+      throw new RuntimeException("Presigned URL 생성 실패", e);
+    }
+  }
+
+  private String generatePresignedUrl(String key, String contentType) {
+    try (S3Presigner presigner = getS3Presigner()) {
+      GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+          .bucket(bucket)
+          .key(key)
+          .responseContentType(contentType)
+          .build();
+
+      GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+          .signatureDuration(Duration.ofSeconds(presignedUrlExpirationSeconds))
+          .getObjectRequest(getObjectRequest)
+          .build();
+
+      PresignedGetObjectRequest presignedRequest = presigner.presignGetObject(presignRequest);
+      return presignedRequest.url().toString();
+    }
+  }
+
+  private S3Presigner getS3Presigner() {
+    return S3Presigner.builder()
+        .region(Region.of(region))
+        .credentialsProvider(
+            StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)
+            )
+        )
+        .build();
+  }
+} 

--- a/3-sprint-mission/src/main/resources/application.yaml
+++ b/3-sprint-mission/src/main/resources/application.yaml
@@ -27,6 +27,9 @@ management:
   endpoint:
     health:
       show-details: always
+  observations:
+    annotations:
+      enabled: true
 
 info:
   name: Discodeit

--- a/3-sprint-mission/src/main/resources/schema.sql
+++ b/3-sprint-mission/src/main/resources/schema.sql
@@ -19,7 +19,8 @@ CREATE TABLE binary_contents
     created_at   timestamp with time zone NOT NULL,
     file_name    varchar(255)             NOT NULL,
     size         bigint                   NOT NULL,
-    content_type varchar(100)             NOT NULL
+    content_type varchar(100)             NOT NULL,
+    status       varchar(20)              NOT NULL
 --     ,bytes        bytea        NOT NULL
 );
 
@@ -56,14 +57,30 @@ CREATE TABLE message_attachments
 -- ReadStatus
 CREATE TABLE read_statuses
 (
-    id           uuid PRIMARY KEY,
-    created_at   timestamp with time zone NOT NULL,
-    updated_at   timestamp with time zone,
-    user_id      uuid                     NOT NULL,
-    channel_id   uuid                     NOT NULL,
-    last_read_at timestamp with time zone NOT NULL,
+    id                   uuid PRIMARY KEY,
+    created_at           timestamp with time zone NOT NULL,
+    updated_at           timestamp with time zone,
+    user_id              uuid                     NOT NULL,
+    channel_id           uuid                     NOT NULL,
+    last_read_at         timestamp with time zone NOT NULL,
+    notification_enabled boolean                  NOT NULL,
     UNIQUE (user_id, channel_id)
 );
+
+-- Notification 테이블 추가
+CREATE TABLE notifications
+(
+    id          uuid PRIMARY KEY,
+    created_at  timestamp with time zone NOT NULL,
+    updated_at  timestamp with time zone,
+    receiver_id uuid                     NOT NULL,
+    title       varchar(255)             NOT NULL,
+    content     text                     NOT NULL
+);
+
+-- 인덱스 추가 (성능 최적화)
+CREATE INDEX idx_notifications_receiver_id_created_at
+    ON notifications (receiver_id, created_at DESC);
 
 
 -- 제약 조건


### PR DESCRIPTION
### Spring Event - 파일 업로드 로직 분리하기
- 디스코드잇은 BinaryContent의 메타 데이터(DB)와 바이너리 데이터(FileSystem/S3)를 분리해 저장합니다.
- 만약 지금처럼 두 로직이 하나의 트랜잭션으로 묶인 경우 트랜잭션을 과도하게 오래 점유할 수 있는 문제가 있습니다.
    - 바이너리 데이터 저장 연산은 오래 걸릴 수 있는 연산이며, 해당 연산이 끝날 때까지 트랜잭션이 대기해야합니다.
- 따라서 Spring Event를 활용해 메타 데이터 저장 트랜잭션으로부터 바이너리 데이터 저장 로직을 분리하여, 메타데이터 저장 트랜잭션이 종료되면 바이너리 데이터를 저장하도록 변경합니다.
- [x]  BinaryContentStorage.put을 직접 호출하는 대신 BinaryContentCreatedEvent를 발행하세요.
    - BinaryContentCreatedEvent를 정의하세요.
        - BinaryContent 메타 정보가 DB에 잘 저장되었다는 사실을 의미하는 이벤트입니다.
    - 다음의 메소드에서 BinaryContentStorage를 호출하는 대신 BinaryContentCreatedEvent를 발행하세요.
        - UserService.create/update
        - MessageService.create
        - BinaryContentService.create
    - ApplicationEventPublisher를 활용하세요.

- [x]  이벤트를 받아 실제 바이너리 데이터를 저장하는 리스너를 구현하세요.
- 이벤트를 발행한 메인 서비스의 트랜잭션이 커밋되었을 때 리스너가 실행되도록 설정하세요.
- BinaryContentStorage를 통해 바이너리 데이터를 저장하세요.
- [x]  바이너리 데이터 저장 성공 여부를 알 수 있도록 메타 데이터를 리팩토링하세요.
    w6750l1ce-image.png
    - BinaryContent에 바이너리 데이터 업로드 상태 속성(status)을 추가하세요.
        ef9unz1z7-image.png
        - PROCESSING: 업로드 중
            - 기본값입니다.
        - SUCCESS: 업로드 완료
        - FAIL: 업로드 실패
        ```sql
        -- schema.sql
        CREATE TABLE binary_contents
        (
            id           uuid PRIMARY KEY,
            created_at   timestamp with time zone NOT NULL,
            updated_at timestamp with time zone,
            file_name    varchar(255)             NOT NULL,
            size         bigint                   NOT NULL,
            content_type varchar(100)             NOT NULL,
            status       varchar(20)              NOT NULL
        );

        -- ALTER TABLE binary_contents
        --      ADD COLUMN updated_at timestamp with time zone;
        -- ALTER TABLE binary_contents
        --      ADD COLUMN status varchar(20) NOT NULL;
        ```
    - BinaryContent의 상태를 업데이트하는 메소드를 정의하세요.
        3o66puyre-image.png
        - 트랜잭션 전파 범위에 유의하세요.
- [x]  바이너리 데이터 저장 성공 여부를 메타 데이터에 반영하세요.
    - 성공 시 BinaryContent의 status를 SUCCESS로 업데이트하세요.
    - 실패 시 BinaryContent의 status를 FAIL로 업데이트하세요.

### Spring Event - 알림 기능 추가하기
- 1)채널에 새로운 메시지가 등록되거나 2)권한이 변경된 경우 이벤트를 발행해 알림을 받을 수 있도록 구현합니다.
- [x] 채널에 새로운 메시지가 등록된 경우 알림을 받을 수 있도록 리팩토링하세요.
    - MessageCreatedEvent를 정의하고 새로운 메시지가 등록되면 이벤트를 발행하세요.
    - 사용자 별로 관심있는 채널의 알림만 받을 수 있도록 ReadStatus 엔티티에 채널 알림 여부 속성(notificationEnabled)을 추가하세요.
        dw0oq8qt4-image.png

        - PRIVATE 채널은 알림 여부를 true로 초기화합니다.
        - PUBLIC 채널은 알림 여부를 false로 초기화합니다.
        ```sql
        -- schema.sql
        CREATE TABLE read_statuses
        (
            id           uuid PRIMARY KEY,
            created_at   timestamp with time zone NOT NULL,
            updated_at   timestamp with time zone,
            user_id      uuid                     NOT NULL,
            channel_id   uuid                     NOT NULL,
            last_read_at timestamp with time zone NOT NULL,
            notification_enabled boolean NOT NULL,
            UNIQUE (user_id, channel_id)
        );

        -- ALTER TABLE read_statuses
        --      ADD COLUMN notification_enabled boolean NOT NULL;
        ```
    - 알림 여부를 수정할 수 있게 ReadStatusUpdateRequest를 수정하세요.
        cy6bs1tea-image.png
        - 알림이 활성화 되어 있는 경우
            qf5fuge9j-image.png
        - 알림이 활성화 되어 있지 않은 경우
            ylp4yrq39-image.png
- [x] 사용자의 권한(Role)이 변경된 경우 알림을 받을 수 있도록 리팩토링하세요.
    - RoleUpdatedEvent를 정의하고 권한이 변경되면 이벤트를 발행하세요.
- [x] 알림 API를 구현하세요.
    - NotificationDto를 정의하세요.
        42xhee8ts-image.png
        - receiverId: 알림을 수신할 User의 id입니다.
    - 알림 조회
        - 엔드포인트: GET /api/notifications
        - 요청
            - 헤더: 엑세스 토큰
        - 응답
            - 200 List<NotifcationDto>
            - 401 ErrorResponse
    - 알림 확인
        - 엔드포인트: DELETE /api/notifications/{notificationId}
        - 요청
            - 헤더: 엑세스 토큰
        - 응답
            - 204 Void
            - 인증되지 않은 요청: 401 ErrorResponse
            - 인가되지 않은 요청: 403 ErrorResponse
                - 요청자 본인의 알림에 대해서만 수행할 수 있습니다.
            - 알림이 없는 경우: 404 ErrorResponse
- [x] 알림이 필요한 이벤트가 발행되었을 때 알림을 생성하세요.
- 이벤트를 처리할 리스너를 구현하세요.
        ```java
        public class NotificationRequiredEventListener {

        @TransactionalEventListener
        public void on(MessageCreatedEvent event) {...}

        @TransactionalEventListener
        public void on(RoleUpdatedEvent event) {...}
        }
        ```
        - on(MessageCreatedEvent)
            - 해당 채널의 알림 여부를 활성화한 ReadStatus를 조회합니다.
            - 해당 ReadStatus의 사용자들에게 알림을 생성합니다.
                ```
                # 알림 예시
                title: "보낸 사람 (#채널명)"
                content: "메시지 내용"
                ```
                7a6dx6rok-image.png

            - 단, 해당 메시지를 보낸 사람은 알림 대상에서 제외합니다.
        - on(RoleUpdatedEvent)
            - 권한이 변경된 당사자에게 알림을 생성합니다.
                ```
                # 알림 예시
                title: "권한이 변경되었습니다."
                content: "USER -> CHANNEL_MANAGER"
                ```
                d8epgul6e-image.png

### 비동기 적용하기
- [x] 비동기를 적용하기 위한 설정(AsyncConfig) 클래스를 구현하세요.
    - @EanbleAsync 어노테이션을 활용하세요.
    - TaskExecutor를 Bean으로 등록하세요.
    - TaskDecorator를 활용해 MDC의 Request ID, SecurityContext의 인정 정보가 비동기 스레드에서도 유지되도록 구현하세요.
- [x] 앞서 구현한 Event Listener를 비동기적으로 처리하세요.
    - @Async 어노테이션을 활용하세요.
- [x] 동기 처리와 비동기 처리 간 성능 차이를 비교해보세요.
    - 파일 업로드 로직에 의도적인 지연(Thread.sleep(…))을 발생시키세요.
        ```java
        // LocalBinaryContentStorage
        public UUID put(UUID binaryContentId, byte[] bytes) {
            try {
            Thread.sleep(3000);
            } catch (InterruptedException e) {
            Thread.currentThread().interrupt();
            throw new RuntimeException("Thread interrupted while simulating delay", e);
            }
            ...
        }
        ```
    - 메시지 생성 API의 실행 시간을 측정해보세요.
        - @Timed 어노테이션을 메소드에 추가합니다.
            ```java
            // MessageController
            @Timed("message.create.async")
            @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
            public ResponseEntity<MessageDto> create(...) {...}
            ```
        - Actuator 설정을 추가합니다.
            ```yaml
            # application.yaml
            management:
                ...
            observations:
                annotations:
                enabled: true
            ```
        - /actuator/metrics/message.create.async 에서 측정된 시간을 확인할 수 있습니다.
    - @EnableAsync를 활성화 / 비활성화 해보면서 동기 / 비동기 처리 간 응답 속도의 차이를 확인해보세요.

### 비동기 실패 처리하기
- 비동기로 처리하는 로직이 실패하는 경우 사용자에게 즉각적인 에러 전파가 되지 않을 가능성이 높습니다.
- 따라서 비동기로 처리하는 로직은 자동 재시도 전략을 통해 더 견고하게 구현해야 합니다.
- 또, 실패하더라도 그 사실을 명확하게 기록해두어야 에러에 대응할 수 있습니다.
- [x] S3를 활용해 바이너리 데이터 저장 시 자동 재시도 매커니즘을 구축하세요.
    - Spring Retry를 위한 환경을 구성하세요.
        - org.springframework.retry:spring-retry 의존성을 추가하세요.
        - @EnableRetry 어노테이션을 활용해 Spring Retry를 활성화 하세요.
    - 바이너리 데이터를 저장하는 메소드에 @Retryable 어노테이션을 사용해 재시도 정책(횟수, 대기 시간 등)을 설정하세요.
- [x] 재시도가 모두 실패했을 때 대응 전략을 구축하세요.
    - @Recover 어노테이션을 활용하세요.
    - 실패 정보를 관리자에게 통지하세요.
        1ubhvrs9g-image.png
        ```
        # 알림 내용 예시
        RequestId: 7641467e369e458a98033558a83321fb
        BinaryContentId: b0549c2a-014c-4761-8b21-4b77d3bd011c
        Error: The AWS Access Key Id you provided does not exist in our records. (Service: S3, Status Code: 403, Request ID: B7KCVSRCGPYJZREX, Extended Request ID: AWRVuJJJ3upwwOkCnd+yhHkgSajUxdg7L4195lbMVTIka6WnBpjZLLRTReoHbgIMf9zzH/QQM0Y5ZOVJCHF2F+l2mSyPG/+8Ee2XBS8hcqk=) (SDK Attempt Count: 1)
        ```
        - 실패 정보에는 추후 디버깅을 위해 필요한 정보를 포함하세요.
            - 실패한 작업 이름
            - MDC의 Request ID
            - 실패 이유 (예외 메시지)

### 캐시 적용하기
- [ ] Caffeine 캐시를 위한 환경을 구성하세요.
    - org.springframework.boot:spring-boot-starter-cache 의존성을 추가하세요.
    - com.github.ben-manes.caffeine:caffeine 의존성을 추가하세요.
    - application.yaml 설정 또는 Bean을 통해 캐시 Caffeine 캐시를 설정하세요.
- [ ] @Cacheable 어노테이션을 활용해 캐시가 필요한 메소드에 적용하세요.
    - 사용자별 채널 목록 조회
    - 사용자별 알림 목록 조회
    - 사용자 목록 조회
[ ] 데이터 변경 시, 캐시를 갱신 또는 무효화하는 로직을 구현하세요.
    - @CacheEvict, @CachePut, CacheManager 등을 활용하세요.
    - 예시:
        - 새로운 채널 추가/수정/삭제 → 채널 목록 캐시 무효화
        - 알림 추가/삭제 → 알림 목록 캐시 무효화
        - 사용자 추가/로그인/로그아웃 → 사용자 목록 캐시 무효화
- [ ] 캐시 적용 전후의 차이를 비교해보세요.
    - 로그를 통해 SQL 실행 여부를 확인해보세요.
- [ ] Spring Actuator를 활용해 캐시 관련 통계 지표를 확인해보세요.
    - Caffein Spec에 recordStats 옵션을 추가하세요.
        ```yaml
        # application.yaml
        cache:
                ...
            caffeine:
            spec: >
                maximumSize=100,
                expireAfterAccess=600s,
                recordStats
    - /actuator/caches, /actuator/metrics/cache.* 를 통해 캐시 관련 데이터를 확인해보세요.
        ```
### 심화 요구사항
### Spring Kafka 도입하기
- 회원이 늘어나면서 알림 연산량이 급증해 알림 기능만 별도의 마이크로 서비스로 분리하기로 결정했다고 가정해봅시다.
- 이제 알림 서비스와 메인 서비스는 완전히 분리된 서버이므로 Spring Event만을 통해서 이벤트를 발행/소비할 수 없습니다.
- 따라서 메인 서비스에서 Kafka를 통해 서버 외부로 이벤트를 발행하고, 알림 서비스에서는 서버 외부의 이벤트를 소비할 수 있도록 해야합니다.
- [ ] Kafka 환경을 구성하세요.
    - Docker Compose를 활용해 Kafka를 구동하세요.
        ```yaml
        # docker-compose-kafka.yaml
        # https://developer.confluent.io/confluent-tutorials/kafka-on-docker/#the-docker-compose-file
        services:
        broker:
            image: apache/kafka:latest
            hostname: broker
            container_name: broker
            ports:
            - 9092:9092
            environment:
            KAFKA_BROKER_ID: 1
            KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
            KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
            KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
            KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
            KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
            KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
            KAFKA_PROCESS_ROLES: broker,controller
            KAFKA_NODE_ID: 1
            KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker:29093
            KAFKA_LISTENERS: PLAINTEXT://broker:29092,CONTROLLER://broker:29093,PLAINTEXT_HOST://0.0.0.0:9092
            KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
            KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
            KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
            CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
        docker compose -f docker-compose-kafka.yml up -d
        ```
    - Spring Kafka 의존성을 추가하고, application.yml에 Kafka 설정을 추가하세요.
        ```gradle
        implementation 'org.springframework.kafka:spring-kafka'
        ```
        ```yaml 
        # application.yaml
        spring:
            ...
        kafka:
            bootstrap-servers: localhost:9092
            producer:
            key-serializer: org.apache.kafka.common.serialization.StringSerializer
            value-serializer: org.apache.kafka.common.serialization.StringSerializer
            consumer:
            group-id: discodeit-group
            auto-offset-reset: earliest
            key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
            value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
        ```
    - [ ]  Spring Event를 Kafka로 발행하는 리스너를 구현하세요.
        - NotificationRequiredEventListener는 비활성화하세요.
        - KafkaProduceRequiredEventListener를 구현하세요.
            ```java
            package com.sprint.mission.discodeit.event.kafka;

            @Slf4j
            @RequiredArgsConstructor
            @Component
            public class KafkaProduceRequiredEventListener {

                private final KafkaTemplate<String, String> kafkaTemplate;
                private final ObjectMapper objectMapper;
                
            @Async("eventTaskExecutor")
            @TransactionalEventListener
            public void on(MessageCreatedEvent event) {
                ...
                String payload = objectMapper.writeValueAsString(event);
                kafkaTemplate.send("discodeit.MessageCreatedEvent", payload);
                ...
            }

            @Async("eventTaskExecutor")
            @TransactionalEventListener
            public void on(RoleUpdatedEvent event) {...}

            @Async("eventTaskExecutor")
            @EventListener
            public void on(S3UploadFailedEvent event) {...}
            }
            ```
        - Spring Event를 Kafka 메시지로 변환해 전송하는 중계 구조입니다.
            60f20el76-image.png
    - [ ]  Kafka Console을 통해 Kafka 이벤트가 잘 발행되는지 확인해보세요.
        1. broker 컨테이너 쉘 접속
            ```
            docker exec -it -w /opt/kafka/bin broker sh
            ```
        2. 토픽 리스트 확인 (실행위치: /opt/kafka/bin)
            ```
            ./kafka-topics.sh --list --bootstrap-server broker:29092

            __consumer_offsets
            discodeit.MessageCreatedEvent
            ...
            ```
        3. 특정 토픽 이벤트 구독 및 대기 (실행위치: /opt/kafka/bin)
            ```
            ./kafka-console-consumer.sh --topic discodeit.MessageCreatedEvent --from-beginning --bootstrap-server broker:29092

            ...
            ```
    - [ ]  Kafka 토픽을 구독해 알림을 생성하는 리스너를 구현하세요.

        - 이 리스너는 메인 서비스와 별도의 서버로 구성된 알림 서비스라고 가정합니다.

        - NotificationRequiredTopicListener를 구현하세요.

            ```java
            package com.sprint.mission.discodeit.event.kafka;

            @Slf4j
            @RequiredArgsConstructor
            @Component
            public class NotificationRequiredTopicListener {
            ...
            private final ObjectMapper objectMapper;

            @KafkaListener(topics = "discodeit.MessageCreatedEvent")
            public void onMessageCreatedEvent(String kafkaEvent) {
                try {
                MessageCreatedEvent event = objectMapper.readValue(kafkaEvent,
                    MessageCreatedEvent.class);
                        ...
                } catch (JsonProcessingException e) {
                throw new RuntimeException(e);
                }
            }

            @KafkaListener(topics = "discodeit.RoleUpdatedEvent")
            public void onRoleUpdatedEvent(String kafkaEvent) {...}

            @KafkaListener(topics = "discodeit.S3UploadFailedEvent")
            public void onS3UploadFailedEvent(String kafkaEvent) {...}
            }
            ```
        - 기존 @EventListener 기반 로직을 제거하고 @KafkaListener로 대체하세요.

### Redis Cache 도입하기
- 대용량 트래픽을 감당하기 위해 서버의 인스턴스를 여러 개로 늘렸다고 가정해봅시다.
- Caffeine과 같은 로컬 캐시는 서로 다른 서버에서 더 이상 활용할 수 없습니다. 
따라서 Redis를 통해 전역 캐시 저장소를 구성합니다.

- [ ]  Redis 환경을 구성하세요.
    - Docker Compose를 활용해 Redis를 구동하세요.
        ```
        # docker-compose-redis.yml
        # https://developer.confluent.io/confluent-tutorials/kafka-on-docker/#the-docker-compose-file
        services:
        redis:
            image: redis:7.2-alpine
            container_name: redis
            ports:
            - "6379:6379"
            volumes:
            - redis-data:/data
            command: redis-server --appendonly yes
        ```
        ```
        docker compose -f docker-compose-redis.yml up -d
        ```
    - Redis 의존성을 추가하고, application.yml에 Redis 설정을 추가하세요.

        ```
        implementation 'com.github.ben-manes.caffeine:caffeine'
        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
        ```
        ```
        # application.yaml
        spring:
        ...
        cache:
            type: caffeine
            type: redis
            cache-names:
            - channels
            - notifications
            - users
            caffeine:
            spec: >
                maximumSize=100,
                expireAfterAccess=600s,
                recordStats
            redis:
            enable-statistics: true
        data:
            redis:
            host: ${REDIS_HOST:localhost}
            port: ${REDIS_PORT:6379}
        ```
    - 직렬화 설정을 위해 다음과 같이 Bean을 선언하세요.
        ```
        // CacheConfig
        @Bean
        public RedisCacheConfiguration redisCacheConfiguration(ObjectMapper objectMapper) {
        ObjectMapper redisObjectMapper = objectMapper.copy();
        redisObjectMapper.activateDefaultTyping(
            LaissezFaireSubTypeValidator.instance,
            DefaultTyping.EVERYTHING,
            As.PROPERTY
        );

        return RedisCacheConfiguration.defaultCacheConfig()
            .serializeValuesWith(
                RedisSerializationContext.SerializationPair.fromSerializer(
                    new GenericJackson2JsonRedisSerializer(redisObjectMapper)
                )
            )
            .prefixCacheNameWith("discodeit:")
            .entryTtl(Duration.ofSeconds(600))
            .disableCachingNullValues();
        }
        ```
- [ ]  DataGrip을 통해 Redis에 저장된 캐시 정보를 조회해보세요.

## 주요 변경사항
- Event 구분
- 비동기 적용

## 멘토에게
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
- 아직 캐시 적용 부분 완성 못했습니당..
