### PR TITLE
[김민준] sprint11

### DIFF
--- a/src/main/java/com/sprint/mission/discodeit/config/AsyncConfig.java
+++ b/src/main/java/com/sprint/mission/discodeit/config/AsyncConfig.java
@@ -1,0 +1,62 @@
+package com.sprint.mission.discodeit.config;
+
+import java.util.List;
+import java.util.Optional;
+import org.jboss.logging.MDC;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.support.CompositeTaskDecorator;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+  @Bean(name = "eventTaskExecutor")
+  public TaskExecutor eventExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(2);
+    executor.setMaxPoolSize(4);
+    executor.setQueueCapacity(100);
+    executor.setThreadNamePrefix("event-task-");
+    executor.setTaskDecorator(
+        new CompositeTaskDecorator(List.of(mdcTaskDecorator(), securityContextTaskDecorator())));
+    executor.initialize();
+    return executor;
+  }
+
+  public TaskDecorator mdcTaskDecorator() {
+    return runnable -> {
+      Optional<String> requestId = Optional.ofNullable(MDC.get(MDCLoggingInterceptor.REQUEST_ID))
+          .map(String.class::cast);
+      return () -> {
+        requestId.ifPresent(id -> MDC.put(MDCLoggingInterceptor.REQUEST_ID, id));
+        try {
+          runnable.run();
+        } finally {
+          requestId.ifPresent(id -> MDC.remove(MDCLoggingInterceptor.REQUEST_ID));
+        }
+      };
+    };
+  }
+
+  public TaskDecorator securityContextTaskDecorator() {
+    return runnable -> {
+      SecurityContext securityContext = SecurityContextHolder.getContext();
+      return () -> {
+        SecurityContextHolder.setContext(securityContext);
+        try {
+          runnable.run();
+        } finally {
+          SecurityContextHolder.clearContext();
+        }
+      };
+    };
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/config/CacheConfig.java
+++ b/src/main/java/com/sprint/mission/discodeit/config/CacheConfig.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.discodeit.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/controller/NotificationController.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/NotificationController.java
@@ -1,0 +1,47 @@
+package com.sprint.mission.discodeit.controller;
+
+import com.sprint.mission.discodeit.controller.api.NotificationApi;
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.security.DiscodeitUserDetails;
+import com.sprint.mission.discodeit.service.NotificationService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController implements NotificationApi {
+
+  private final NotificationService notificationService;
+
+  @GetMapping
+  public ResponseEntity<List<NotificationDto>> findAllByReceiverId(
+      @AuthenticationPrincipal DiscodeitUserDetails principal) {
+    UUID receiverId = principal.getUserDto().id();
+    log.info("알림 목록 조회 요청: receiverId={}", receiverId);
+    List<NotificationDto> notifications = notificationService.findAllByReceiverId(receiverId);
+    log.debug("알림 목록 조회 응답: count={}", notifications.size());
+    return ResponseEntity.ok(notifications);
+  }
+
+  @DeleteMapping("/{notificationId}")
+  public ResponseEntity<Void> delete(
+      @AuthenticationPrincipal DiscodeitUserDetails principal,
+      @PathVariable UUID notificationId) {
+    UUID receiverId = principal.getUserDto().id();
+    log.info("알림 삭제 요청: id={}, receiverId={}", notificationId, receiverId);
+    notificationService.delete(notificationId, receiverId);
+    log.debug("알림 삭제 응답: id={}", notificationId);
+    return ResponseEntity.noContent().build();
+  }
+} 

--- a/src/main/java/com/sprint/mission/discodeit/controller/api/NotificationApi.java
+++ b/src/main/java/com/sprint/mission/discodeit/controller/api/NotificationApi.java
@@ -1,0 +1,54 @@
+package com.sprint.mission.discodeit.controller.api;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.security.DiscodeitUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Notification", description = "알림 API")
+public interface NotificationApi {
+
+  @Operation(summary = "알림 목록 조회")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200", description = "알림 목록 조회 성공",
+          content = @Content(array = @ArraySchema(schema = @Schema(implementation = NotificationDto.class)))
+      ),
+      @ApiResponse(
+          responseCode = "401", description = "인증되지 않은 요청",
+          content = @Content(schema = @Schema(hidden = true))
+      )
+  })
+  ResponseEntity<List<NotificationDto>> findAllByReceiverId(
+      @Parameter(hidden = true) DiscodeitUserDetails principal
+  );
+
+  @Operation(summary = "알림 삭제 (알림 확인)")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "204", description = "알림 삭제 성공",
+          content = @Content(schema = @Schema(hidden = true))
+      ),
+      @ApiResponse(
+          responseCode = "401", description = "인증되지 않은 요청",
+          content = @Content(schema = @Schema(hidden = true))
+      ),
+      @ApiResponse(
+          responseCode = "404", description = "알림을 찾을 수 없음",
+          content = @Content(schema = @Schema(hidden = true))
+      )
+  })
+  ResponseEntity<Void> delete(
+      @Parameter(hidden = true) DiscodeitUserDetails principal,
+      @Parameter(description = "알림 ID") UUID notificationId
+  );
+} 

--- a/src/main/java/com/sprint/mission/discodeit/dto/data/NotificationDto.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/data/NotificationDto.java
@@ -1,0 +1,14 @@
+package com.sprint.mission.discodeit.dto.data;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationDto(
+    UUID id,
+    Instant createdAt,
+    UUID receiverId,
+    String title,
+    String content
+) {
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/BinaryContentStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/BinaryContentStatus.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.entity;
+
+public enum BinaryContentStatus {
+  PROCESSING,
+  SUCCESS,
+  FAIL
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/Notification.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Notification.java
@@ -1,0 +1,32 @@
+package com.sprint.mission.discodeit.entity;
+
+import com.sprint.mission.discodeit.entity.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+  @Column(name = "receiver_id", columnDefinition = "uuid", nullable = false)
+  private UUID receiverId;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(nullable = false)
+  private String content;
+
+  public Notification(UUID receiverId, String title, String content) {
+    this.receiverId = receiverId;
+    this.title = title;
+    this.content = content;
+  }
+} 

--- a/src/main/java/com/sprint/mission/discodeit/event/listener/BinaryContentEventListener.java
+++ b/src/main/java/com/sprint/mission/discodeit/event/listener/BinaryContentEventListener.java
@@ -1,0 +1,40 @@
+package com.sprint.mission.discodeit.event.listener;
+
+import com.sprint.mission.discodeit.entity.BinaryContent;
+import com.sprint.mission.discodeit.entity.BinaryContentStatus;
+import com.sprint.mission.discodeit.event.message.BinaryContentCreatedEvent;
+import com.sprint.mission.discodeit.service.BinaryContentService;
+import com.sprint.mission.discodeit.storage.BinaryContentStorage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class BinaryContentEventListener {
+
+  private final BinaryContentService binaryContentService;
+  private final BinaryContentStorage binaryContentStorage;
+
+  @Async("eventTaskExecutor")
+  @TransactionalEventListener
+  public void on(BinaryContentCreatedEvent event) {
+    BinaryContent binaryContent = event.getData();
+    try {
+      binaryContentStorage.put(
+          binaryContent.getId(),
+          event.getBytes()
+      );
+      binaryContentService.updateStatus(
+          binaryContent.getId(), BinaryContentStatus.SUCCESS
+      );
+    } catch (RuntimeException e) {
+      binaryContentService.updateStatus(
+          binaryContent.getId(), BinaryContentStatus.FAIL
+      );
+    }
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/event/listener/NotificationRequiredEventListener.java
+++ b/src/main/java/com/sprint/mission/discodeit/event/listener/NotificationRequiredEventListener.java
@@ -1,0 +1,95 @@
+package com.sprint.mission.discodeit.event.listener;
+
+import com.sprint.mission.discodeit.dto.data.ChannelDto;
+import com.sprint.mission.discodeit.dto.data.MessageDto;
+import com.sprint.mission.discodeit.entity.ChannelType;
+import com.sprint.mission.discodeit.entity.Role;
+import com.sprint.mission.discodeit.event.message.MessageCreatedEvent;
+import com.sprint.mission.discodeit.event.message.RoleUpdatedEvent;
+import com.sprint.mission.discodeit.event.message.S3UploadFailedEvent;
+import com.sprint.mission.discodeit.repository.ReadStatusRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.service.NotificationService;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class NotificationRequiredEventListener {
+
+  private final NotificationService notificationService;
+  private final ReadStatusRepository readStatusRepository;
+  private final ChannelService channelService;
+  private final UserRepository userRepository;
+
+  @Value("${discodeit.admin.username}")
+  private String adminUsername;
+
+
+  @Async("eventTaskExecutor")
+  @TransactionalEventListener
+  public void on(MessageCreatedEvent event) {
+    MessageDto message = event.getData();
+    UUID channelId = message.channelId();
+    ChannelDto channel = channelService.find(channelId);
+
+    Set<UUID> receiverIds = readStatusRepository.findAllByChannelIdAndNotificationEnabledTrue(
+            channelId)
+        .stream().map(readStatus -> readStatus.getUser().getId())
+        .filter(receiverId -> !receiverId.equals(message.author().id()))
+        .collect(Collectors.toSet());
+    String title = message.author().username()
+        .concat(
+            channel.type().equals(ChannelType.PUBLIC) ?
+                String.format(" (#%s)", channel.name()) : ""
+        );
+    String content = message.content();
+
+    notificationService.create(receiverIds, title, content);
+  }
+
+  @Async("eventTaskExecutor")
+  @TransactionalEventListener
+  public void on(RoleUpdatedEvent event) {
+    UUID userId = event.getUserId();
+    Role from = event.getFrom();
+    Role to = event.getTo();
+
+    String title = "권한이 변경되었습니다.";
+    String content = String.format("%s -> %s", from.name(), to.name());
+
+    notificationService.create(Set.of(userId), title, content);
+  }
+
+  @Async("eventTaskExecutor")
+  @EventListener
+  public void on(S3UploadFailedEvent event) {
+    String requestId = event.getRequestId();
+    UUID binaryContentId = event.getBinaryContentId();
+    Throwable e = event.getE();
+
+    String title = "S3 파일 업로드 실패";
+
+    StringBuffer sb = new StringBuffer();
+    sb.append("RequestId: ").append(requestId).append("\n");
+    sb.append("BinaryContentId: ").append(binaryContentId).append("\n");
+    sb.append("Error: ").append(e.getMessage()).append("\n");
+    String content = sb.toString();
+
+    Set<UUID> receiverIds = userRepository.findByUsername(adminUsername)
+        .map(user -> Set.of(user.getId()))
+        .orElse(Set.of());
+
+    notificationService.create(receiverIds, title, content);
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/event/message/BinaryContentCreatedEvent.java
+++ b/src/main/java/com/sprint/mission/discodeit/event/message/BinaryContentCreatedEvent.java
@@ -1,0 +1,16 @@
+package com.sprint.mission.discodeit.event.message;
+
+import com.sprint.mission.discodeit.entity.BinaryContent;
+import java.time.Instant;
+import lombok.Getter;
+
+@Getter
+public class BinaryContentCreatedEvent extends CreatedEvent<BinaryContent> {
+
+  private final byte[] bytes;
+
+  public BinaryContentCreatedEvent(BinaryContent data, Instant createdAt, byte[] bytes) {
+    super(data, createdAt);
+    this.bytes = bytes;
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/event/message/CreatedEvent.java
+++ b/src/main/java/com/sprint/mission/discodeit/event/message/CreatedEvent.java
@@ -1,0 +1,16 @@
+package com.sprint.mission.discodeit.event.message;
+
+import java.time.Instant;
+import lombok.Getter;
+
+@Getter
+public abstract class CreatedEvent<T> {
+
+  private final T data;
+  private final Instant createdAt;
+
+  protected CreatedEvent(final T data, final Instant createdAt) {
+    this.data = data;
+    this.createdAt = createdAt;
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/event/message/DeletedEvent.java
+++ b/src/main/java/com/sprint/mission/discodeit/event/message/DeletedEvent.java
@@ -1,0 +1,16 @@
+package com.sprint.mission.discodeit.event.message;
+
+import java.time.Instant;
+import lombok.Getter;
+
+@Getter
+public abstract class DeletedEvent<T> {
+
+  private final T data;
+  private final Instant deletedAt;
+
+  protected DeletedEvent(final T data, final Instant deletedAt) {
+    this.data = data;
+    this.deletedAt = deletedAt;
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/event/message/MessageCreatedEvent.java
+++ b/src/main/java/com/sprint/mission/discodeit/event/message/MessageCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.discodeit.event.message;
+
+import com.sprint.mission.discodeit.dto.data.MessageDto;
+import java.time.Instant;
+
+public class MessageCreatedEvent extends CreatedEvent<MessageDto> {
+
+  public MessageCreatedEvent(MessageDto data, Instant createdAt) {
+    super(data, createdAt);
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/event/message/RoleUpdatedEvent.java
+++ b/src/main/java/com/sprint/mission/discodeit/event/message/RoleUpdatedEvent.java
@@ -1,0 +1,17 @@
+package com.sprint.mission.discodeit.event.message;
+
+import com.sprint.mission.discodeit.entity.Role;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class RoleUpdatedEvent extends UpdatedEvent<Role> {
+
+  private final UUID userId;
+
+  public RoleUpdatedEvent(UUID userId, Role from, Role to, Instant updatedAt) {
+    super(from, to, updatedAt);
+    this.userId = userId;
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/event/message/S3UploadFailedEvent.java
+++ b/src/main/java/com/sprint/mission/discodeit/event/message/S3UploadFailedEvent.java
@@ -1,0 +1,20 @@
+package com.sprint.mission.discodeit.event.message;
+
+import com.sprint.mission.discodeit.config.MDCLoggingInterceptor;
+import java.util.UUID;
+import lombok.Getter;
+import org.slf4j.MDC;
+
+@Getter
+public class S3UploadFailedEvent {
+
+  private final UUID binaryContentId;
+  private final Throwable e;
+  private final String requestId;
+
+  public S3UploadFailedEvent(UUID binaryContentId, Throwable e) {
+    this.binaryContentId = binaryContentId;
+    this.e = e;
+    this.requestId = MDC.get(MDCLoggingInterceptor.REQUEST_ID);
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/event/message/UpdatedEvent.java
+++ b/src/main/java/com/sprint/mission/discodeit/event/message/UpdatedEvent.java
@@ -1,0 +1,18 @@
+package com.sprint.mission.discodeit.event.message;
+
+import java.time.Instant;
+import lombok.Getter;
+
+@Getter
+public abstract class UpdatedEvent<T> {
+
+  private final T from;
+  private final T to;
+  private final Instant updatedAt;
+
+  protected UpdatedEvent(final T from, final T to, final Instant updatedAt) {
+    this.from = from;
+    this.to = to;
+    this.updatedAt = updatedAt;
+  }
+}

--- a/src/main/java/com/sprint/mission/discodeit/exception/notification/NotificationException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/notification/NotificationException.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.exception.notification;
+
+import com.sprint.mission.discodeit.exception.DiscodeitException;
+import com.sprint.mission.discodeit.exception.ErrorCode;
+
+public class NotificationException extends DiscodeitException {
+
+  public NotificationException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public NotificationException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+} 

--- a/src/main/java/com/sprint/mission/discodeit/exception/notification/NotificationForbiddenException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/notification/NotificationForbiddenException.java
@@ -1,0 +1,18 @@
+package com.sprint.mission.discodeit.exception.notification;
+
+import com.sprint.mission.discodeit.exception.ErrorCode;
+import java.util.UUID;
+
+public class NotificationForbiddenException extends NotificationException {
+
+  public NotificationForbiddenException() {
+    super(ErrorCode.NOTIFICATION_FORBIDDEN);
+  }
+
+  public static NotificationForbiddenException withId(UUID notificationId, UUID receiverId) {
+    NotificationForbiddenException exception = new NotificationForbiddenException();
+    exception.addDetail("notificationId", notificationId);
+    exception.addDetail("receiverId", receiverId);
+    return exception;
+  }
+} 

--- a/src/main/java/com/sprint/mission/discodeit/exception/notification/NotificationNotFoundException.java
+++ b/src/main/java/com/sprint/mission/discodeit/exception/notification/NotificationNotFoundException.java
@@ -1,0 +1,17 @@
+package com.sprint.mission.discodeit.exception.notification;
+
+import com.sprint.mission.discodeit.exception.ErrorCode;
+import java.util.UUID;
+
+public class NotificationNotFoundException extends NotificationException {
+
+  public NotificationNotFoundException() {
+    super(ErrorCode.NOTIFICATION_NOT_FOUND);
+  }
+
+  public static NotificationNotFoundException withId(UUID notificationId) {
+    NotificationNotFoundException exception = new NotificationNotFoundException();
+    exception.addDetail("notificationId", notificationId);
+    return exception;
+  }
+} 

--- a/src/main/java/com/sprint/mission/discodeit/mapper/NotificationMapper.java
+++ b/src/main/java/com/sprint/mission/discodeit/mapper/NotificationMapper.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.discodeit.mapper;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.entity.Notification;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface NotificationMapper {
+
+  NotificationDto toDto(Notification notification);
+} 

--- a/src/main/java/com/sprint/mission/discodeit/repository/NotificationRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/NotificationRepository.java
@@ -1,0 +1,13 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.Notification;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+
+  List<Notification> findAllByReceiverIdOrderByCreatedAtDesc(UUID receiverId);
+
+  void deleteByIdAndReceiverId(UUID id, UUID receiverId);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/NotificationService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/NotificationService.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+public interface NotificationService {
+
+  List<NotificationDto> findAllByReceiverId(UUID receiverId);
+
+  void delete(UUID notificationId, UUID receiverId);
+
+  void create(Set<UUID> receiverIds, String title, String content);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicNotificationService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicNotificationService.java
@@ -1,0 +1,92 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.entity.Notification;
+import com.sprint.mission.discodeit.exception.notification.NotificationForbiddenException;
+import com.sprint.mission.discodeit.exception.notification.NotificationNotFoundException;
+import com.sprint.mission.discodeit.mapper.NotificationMapper;
+import com.sprint.mission.discodeit.repository.NotificationRepository;
+import com.sprint.mission.discodeit.service.NotificationService;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class BasicNotificationService implements NotificationService {
+
+  private final NotificationRepository notificationRepository;
+  private final NotificationMapper notificationMapper;
+  private final CacheManager cacheManager;
+
+  @Cacheable(value = "notifications", key = "#receiverId", unless = "#result.isEmpty()")
+  @PreAuthorize("principal.userDto.id == #receiverId")
+  @Override
+  public List<NotificationDto> findAllByReceiverId(UUID receiverId) {
+    log.debug("알림 목록 조회 시작: receiverId={}", receiverId);
+    List<NotificationDto> notifications = notificationRepository.findAllByReceiverIdOrderByCreatedAtDesc(
+            receiverId)
+        .stream()
+        .map(notificationMapper::toDto)
+        .toList();
+    log.info("알림 목록 조회 완료: receiverId={}, 조회된 항목 수={}", receiverId, notifications.size());
+    return notifications;
+  }
+
+  @CacheEvict(value = "notifications", key = "#receiverId")
+  @PreAuthorize("principal.userDto.id == #receiverId")
+  @Transactional
+  @Override
+  public void delete(UUID notificationId, UUID receiverId) {
+    log.debug("알림 삭제 시작: id={}, receiverId={}", notificationId, receiverId);
+    Notification notification = notificationRepository.findById(notificationId)
+        .orElseThrow(() -> NotificationNotFoundException.withId(notificationId));
+    if (!notification.getReceiverId().equals(receiverId)) {
+      log.warn("알림 삭제 권한 없음: id={}, receiverId={}", notificationId, receiverId);
+      throw NotificationForbiddenException.withId(notificationId, receiverId);
+    }
+    notificationRepository.delete(notification);
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @Override
+  public void create(Set<UUID> receiverIds, String title, String content) {
+    if (receiverIds.isEmpty()) {
+      log.warn("알림 생성 요청이 비어있음: receiverIds={}", receiverIds);
+      return;
+    }
+    log.debug("새 알림 생성 시작: receiverIds={}", receiverIds);
+    List<Notification> notifications = receiverIds.stream()
+        .map(receiverId -> new Notification(
+            receiverId,
+            title,
+            content
+        )).toList();
+    notificationRepository.saveAll(notifications);
+    evictNotificationCache(receiverIds);
+    log.info("새 알림 생성 완료: receiverIds={}", receiverIds);
+  }
+
+  private void evictNotificationCache(Set<UUID> receiverIds) {
+    Cache cache = cacheManager.getCache("notifications");
+    if (cache != null) {
+      for (UUID receiverId : receiverIds) {
+        cache.evict(receiverId);
+      }
+      log.debug("알림 캐시를 제거했습니다: receiverIds={}", receiverIds);
+    } else {
+      log.warn("알림 캐시가 존재하지 않습니다.");
+    }
+  }
+} 

--- a/src/test/java/com/sprint/mission/discodeit/controller/NotificationControllerTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/controller/NotificationControllerTest.java
@@ -1,0 +1,140 @@
+package com.sprint.mission.discodeit.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.dto.data.UserDto;
+import com.sprint.mission.discodeit.entity.Role;
+import com.sprint.mission.discodeit.exception.notification.NotificationNotFoundException;
+import com.sprint.mission.discodeit.security.DiscodeitUserDetails;
+import com.sprint.mission.discodeit.service.NotificationService;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@WebMvcTest(value = NotificationController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.REGEX,
+        pattern = ".*\\.security\\.jwt\\..*"))
+class NotificationControllerTest {
+
+
+  @MockitoBean
+  private NotificationService notificationService;
+
+  @Autowired
+  private NotificationController notificationController;
+
+  @Test
+  @DisplayName("알림 목록 조회 성공 테스트")
+  void findAllByReceiverId_Success() {
+    // Given
+    UUID receiverId = UUID.randomUUID();
+    UUID notificationId1 = UUID.randomUUID();
+    UUID notificationId2 = UUID.randomUUID();
+    Instant now = Instant.now();
+
+    UserDto userDto = new UserDto(receiverId, "testuser", "test@example.com", null, true, Role.USER);
+    DiscodeitUserDetails principal = new DiscodeitUserDetails(userDto, "password");
+
+    List<NotificationDto> notifications = List.of(
+        new NotificationDto(
+            notificationId1,
+            now.minusSeconds(60),
+            receiverId,
+            "새 메시지",
+            "user1이 메시지를 보냈습니다."
+        ),
+        new NotificationDto(
+            notificationId2,
+            now.minusSeconds(120),
+            receiverId,
+            "권한 변경",
+            "USER -> ADMIN"
+        )
+    );
+
+    given(notificationService.findAllByReceiverId(receiverId)).willReturn(notifications);
+
+    // When
+    ResponseEntity<List<NotificationDto>> response = notificationController.findAllByReceiverId(principal);
+
+    // Then
+    assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+    List<NotificationDto> result = response.getBody();
+    assertThat(result).isNotNull()
+        .hasSize(2);
+    assertThat(result.get(0).id()).isEqualTo(notificationId1);
+    assertThat(result.get(0).title()).isEqualTo("새 메시지");
+    assertThat(result.get(1).id()).isEqualTo(notificationId2);
+    assertThat(result.get(1).title()).isEqualTo("권한 변경");
+  }
+
+  @Test
+  @DisplayName("알림 목록 조회 - 빈 목록")
+  void findAllByReceiverId_EmptyList() {
+    // Given
+    UUID receiverId = UUID.randomUUID();
+    UserDto userDto = new UserDto(receiverId, "testuser", "test@example.com", null, true, Role.USER);
+    DiscodeitUserDetails principal = new DiscodeitUserDetails(userDto, "password");
+
+    given(notificationService.findAllByReceiverId(receiverId)).willReturn(List.of());
+
+    // When
+    ResponseEntity<List<NotificationDto>> response = notificationController.findAllByReceiverId(principal);
+
+    // Then
+    assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+    List<NotificationDto> result = response.getBody();
+    assertThat(result).isNotNull()
+        .isEmpty();
+  }
+
+  @Test
+  @DisplayName("알림 삭제 성공 테스트")
+  void delete_Success() {
+    // Given
+    UUID receiverId = UUID.randomUUID();
+    UUID notificationId = UUID.randomUUID();
+    UserDto userDto = new UserDto(receiverId, "testuser", "test@example.com", null, true, Role.USER);
+    DiscodeitUserDetails principal = new DiscodeitUserDetails(userDto, "password");
+
+    willDoNothing().given(notificationService).delete(notificationId, receiverId);
+
+    // When
+    ResponseEntity<Void> response = notificationController.delete(principal, notificationId);
+
+    // Then
+    assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+    assertThat(response.getStatusCode().value()).isEqualTo(204);
+  }
+
+  @Test
+  @DisplayName("알림 삭제 실패 테스트 - 존재하지 않는 알림")
+  void delete_Failure_NotificationNotFound() {
+    // Given
+    UUID receiverId = UUID.randomUUID();
+    UUID nonExistentNotificationId = UUID.randomUUID();
+    UserDto userDto = new UserDto(receiverId, "testuser", "test@example.com", null, true, Role.USER);
+    DiscodeitUserDetails principal = new DiscodeitUserDetails(userDto, "password");
+
+    willThrow(NotificationNotFoundException.withId(nonExistentNotificationId))
+        .given(notificationService).delete(nonExistentNotificationId, receiverId);
+
+    // When & Then
+    assertThatThrownBy(() -> notificationController.delete(principal, nonExistentNotificationId))
+        .isInstanceOf(NotificationNotFoundException.class);
+  }
+}

--- a/src/test/java/com/sprint/mission/discodeit/event/listener/BinaryContentEventListenerTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/event/listener/BinaryContentEventListenerTest.java
@@ -1,0 +1,103 @@
+package com.sprint.mission.discodeit.event.listener;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.sprint.mission.discodeit.entity.BinaryContent;
+import com.sprint.mission.discodeit.entity.BinaryContentStatus;
+import com.sprint.mission.discodeit.event.message.BinaryContentCreatedEvent;
+import com.sprint.mission.discodeit.service.BinaryContentService;
+import com.sprint.mission.discodeit.storage.BinaryContentStorage;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BinaryContentEventListenerTest {
+
+  @Mock
+  private BinaryContentService binaryContentService;
+
+  @Mock
+  private BinaryContentStorage binaryContentStorage;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+
+  @InjectMocks
+  private BinaryContentEventListener binaryContentEventListener;
+
+  private UUID binaryContentId;
+  private BinaryContent binaryContent;
+  private byte[] testBytes;
+  private BinaryContentCreatedEvent event;
+
+  @BeforeEach
+  void setUp() {
+    binaryContentId = UUID.randomUUID();
+    testBytes = "test content".getBytes();
+    binaryContent = new BinaryContent("test.txt", (long) testBytes.length, "text/plain");
+    ReflectionTestUtils.setField(binaryContent, "id", binaryContentId);
+    
+    event = new BinaryContentCreatedEvent(binaryContent, Instant.now(), testBytes);
+  }
+
+  @Test
+  @DisplayName("파일 업로드 성공 시 상태를 SUCCESS로 업데이트")
+  void on_Success() {
+    // given
+    given(binaryContentStorage.put(binaryContentId, testBytes)).willReturn(binaryContentId);
+
+    // when
+    binaryContentEventListener.on(event);
+
+    // then
+    verify(binaryContentStorage).put(binaryContentId, testBytes);
+    verify(binaryContentService).updateStatus(binaryContentId, BinaryContentStatus.SUCCESS);
+  }
+
+  @Test
+  @DisplayName("파일 업로드 실패 시 상태를 FAIL로 업데이트")
+  void on_StorageFailure() {
+    // given
+    given(binaryContentStorage.put(binaryContentId, testBytes))
+        .willThrow(new RuntimeException("Storage error"));
+
+    // when
+    binaryContentEventListener.on(event);
+
+    // then
+    verify(binaryContentStorage).put(binaryContentId, testBytes);
+    verify(binaryContentService).updateStatus(binaryContentId, BinaryContentStatus.FAIL);
+  }
+
+  @Test
+  @DisplayName("상태 업데이트 실패 시 저장소에는 저장하지만 상태 업데이트는 실패")
+  void on_StatusUpdateFailure() {
+    // given
+    given(binaryContentStorage.put(binaryContentId, testBytes)).willReturn(binaryContentId);
+    given(binaryContentService.updateStatus(eq(binaryContentId), any(BinaryContentStatus.class)))
+        .willThrow(new RuntimeException("Update failed"));
+
+    // when
+    try {
+      binaryContentEventListener.on(event);
+    } catch (RuntimeException e) {
+      // Exception should be handled within the listener
+    }
+
+    // then
+    verify(binaryContentStorage).put(binaryContentId, testBytes);
+    verify(binaryContentService).updateStatus(binaryContentId, BinaryContentStatus.SUCCESS);
+  }
+}

--- a/src/test/java/com/sprint/mission/discodeit/event/listener/NotificationRequiredEventListenerTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/event/listener/NotificationRequiredEventListenerTest.java
@@ -1,0 +1,262 @@
+package com.sprint.mission.discodeit.event.listener;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.sprint.mission.discodeit.dto.data.ChannelDto;
+import com.sprint.mission.discodeit.dto.data.MessageDto;
+import com.sprint.mission.discodeit.dto.data.UserDto;
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.ChannelType;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.entity.Role;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.event.message.MessageCreatedEvent;
+import com.sprint.mission.discodeit.event.message.RoleUpdatedEvent;
+import com.sprint.mission.discodeit.repository.ReadStatusRepository;
+import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.service.NotificationService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationRequiredEventListenerTest {
+
+  @Mock
+  private NotificationService notificationService;
+
+  @Mock
+  private ReadStatusRepository readStatusRepository;
+
+  @Mock
+  private ChannelService channelService;
+
+  @InjectMocks
+  private NotificationRequiredEventListener eventListener;
+
+  private UUID authorId;
+  private UUID channelId;
+  private UUID privateChannelId;
+  private UUID receiverId1;
+  private UUID receiverId2;
+  private MessageDto messageDto;
+  private ChannelDto publicChannelDto;
+  private ChannelDto privateChannelDto;
+  private UserDto authorDto;
+
+  @BeforeEach
+  void setUp() {
+    authorId = UUID.randomUUID();
+    channelId = UUID.randomUUID();
+    privateChannelId = UUID.randomUUID();
+    receiverId1 = UUID.randomUUID();
+    receiverId2 = UUID.randomUUID();
+
+    authorDto = new UserDto(
+        authorId,
+        "author",
+        "author@example.com",
+        null,
+        true,
+        Role.USER
+    );
+
+    messageDto = new MessageDto(
+        UUID.randomUUID(),
+        Instant.now(),
+        Instant.now(),
+        "Hello world",
+        channelId,
+        authorDto,
+        List.of()
+    );
+
+    publicChannelDto = new ChannelDto(
+        channelId,
+        ChannelType.PUBLIC,
+        "general",
+        "General chat",
+        List.of(),
+        Instant.now()
+    );
+
+    privateChannelDto = new ChannelDto(
+        privateChannelId,
+        ChannelType.PRIVATE,
+        null,
+        null,
+        List.of(),
+        Instant.now()
+    );
+  }
+
+  @Test
+  @DisplayName("PublicChannel에서 메시지 생성 시 알림 생성")
+  void onMessageCreated_PublicChannel_CreatesNotifications() {
+    // given
+    MessageCreatedEvent event = new MessageCreatedEvent(messageDto, messageDto.createdAt());
+
+    User user1 = createMockUser(receiverId1);
+    User user2 = createMockUser(receiverId2);
+
+    ReadStatus readStatus1 = createMockReadStatus(user1, true);
+    ReadStatus readStatus2 = createMockReadStatus(user2, true);
+
+    given(channelService.find(channelId)).willReturn(publicChannelDto);
+    given(readStatusRepository.findAllByChannelIdAndNotificationEnabledTrue(channelId))
+        .willReturn(List.of(readStatus1, readStatus2));
+
+    String expectedTitle = "author (#general)";
+    String expectedContent = "Hello world";
+
+    // when
+    eventListener.on(event);
+
+    // then
+    verify(notificationService).create(
+        eq(Set.of(receiverId1, receiverId2)),
+        eq(expectedTitle),
+        eq(expectedContent)
+    );
+  }
+
+  @Test
+  @DisplayName("PrivateChannel에서 메시지 생성 시 알림 생성")
+  void onMessageCreated_PrivateChannel_CreatesNotifications() {
+    // given
+    MessageCreatedEvent event = new MessageCreatedEvent(messageDto, messageDto.createdAt());
+
+    User user1 = createMockUser(receiverId1);
+    ReadStatus readStatus1 = createMockReadStatus(user1, true);
+
+    given(channelService.find(channelId)).willReturn(privateChannelDto);
+    given(readStatusRepository.findAllByChannelIdAndNotificationEnabledTrue(channelId))
+        .willReturn(List.of(readStatus1));
+
+    String expectedTitle = "author"; // No channel name for private channels
+    String expectedContent = "Hello world";
+
+    // when
+    eventListener.on(event);
+
+    // then
+    verify(notificationService).create(
+        eq(Set.of(receiverId1)),
+        eq(expectedTitle),
+        eq(expectedContent)
+    );
+  }
+
+  @Test
+  @DisplayName("메시지 작성자는 알림 수신자에서 제외")
+  void onMessageCreated_ExcludesAuthorFromReceivers() {
+    // given
+    MessageCreatedEvent event = new MessageCreatedEvent(messageDto, messageDto.createdAt());
+
+    User authorUser = createMockUser(authorId);
+    User receiverUser = createMockUser(receiverId1);
+
+    ReadStatus authorReadStatus = createMockReadStatus(authorUser, true);
+    ReadStatus receiverReadStatus = createMockReadStatus(receiverUser, true);
+
+    given(channelService.find(channelId)).willReturn(publicChannelDto);
+    given(readStatusRepository.findAllByChannelIdAndNotificationEnabledTrue(channelId))
+        .willReturn(List.of(authorReadStatus, receiverReadStatus));
+
+    // when
+    eventListener.on(event);
+
+    // then
+    verify(notificationService).create(
+        eq(Set.of(receiverId1)), // Only receiver, not author
+        any(String.class),
+        any(String.class)
+    );
+  }
+
+  @Test
+  @DisplayName("알림이 비활성화된 사용자는 알림 수신자에서 제외")
+  void onMessageCreated_ExcludesDisabledNotificationUsers() {
+    // given
+    MessageCreatedEvent event = new MessageCreatedEvent(messageDto, messageDto.createdAt());
+
+    // Test scenario: repository returns empty list for users with notifications enabled
+
+    given(channelService.find(channelId)).willReturn(publicChannelDto);
+    given(readStatusRepository.findAllByChannelIdAndNotificationEnabledTrue(channelId))
+        .willReturn(List.of()); // No users with notifications enabled
+
+    // when
+    eventListener.on(event);
+
+    // then
+    verify(notificationService).create(eq(Set.of()), any(String.class), any(String.class));
+  }
+
+  @Test
+  @DisplayName("역할 변경 이벤트 시 알림 생성")
+  void onRoleUpdated_CreatesNotification() {
+    // given
+    UUID userId = UUID.randomUUID();
+    Role fromRole = Role.USER;
+    Role toRole = Role.ADMIN;
+    Instant updatedAt = Instant.now();
+
+    RoleUpdatedEvent event = new RoleUpdatedEvent(userId, fromRole, toRole, updatedAt);
+
+    String expectedTitle = "권한이 변경되었습니다.";
+    String expectedContent = "USER -> ADMIN";
+
+    // when
+    eventListener.on(event);
+
+    // then
+    verify(notificationService).create(
+        eq(Set.of(userId)),
+        eq(expectedTitle),
+        eq(expectedContent)
+    );
+  }
+
+  @Test
+  @DisplayName("수신자가 없을 때는 알림을 생성하지 않음")
+  void onMessageCreated_NoReceivers_NoNotificationCreated() {
+    // given
+    MessageCreatedEvent event = new MessageCreatedEvent(messageDto, messageDto.createdAt());
+
+    given(channelService.find(channelId)).willReturn(publicChannelDto);
+    given(readStatusRepository.findAllByChannelIdAndNotificationEnabledTrue(channelId))
+        .willReturn(List.of());
+
+    // when
+    eventListener.on(event);
+
+    // then
+    verify(notificationService).create(eq(Set.of()), any(String.class), any(String.class));
+  }
+
+  private User createMockUser(UUID userId) {
+    User user = new User("user", "user@example.com", "password", null);
+    ReflectionTestUtils.setField(user, "id", userId);
+    return user;
+  }
+
+  private ReadStatus createMockReadStatus(User user, boolean notificationEnabled) {
+    Channel mockChannel = new Channel(ChannelType.PUBLIC, "test", "test");
+    ReadStatus readStatus = new ReadStatus(user, mockChannel, Instant.now());
+    ReflectionTestUtils.setField(readStatus, "notificationEnabled", notificationEnabled);
+    return readStatus;
+  }
+}

--- a/src/test/java/com/sprint/mission/discodeit/integration/NotificationApiIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/integration/NotificationApiIntegrationTest.java
@@ -1,0 +1,200 @@
+package com.sprint.mission.discodeit.integration;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sprint.mission.discodeit.dto.data.UserDto;
+import com.sprint.mission.discodeit.dto.request.UserCreateRequest;
+import com.sprint.mission.discodeit.security.DiscodeitUserDetails;
+import com.sprint.mission.discodeit.service.NotificationService;
+import com.sprint.mission.discodeit.service.UserService;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("알림 API 통합 테스트")
+class NotificationApiIntegrationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private NotificationService notificationService;
+
+  @Autowired
+  private UserService userService;
+
+  @Test
+  @DisplayName("알림 목록 조회 API 통합 테스트")
+  void findAllByReceiverId_IntegrationTest() throws Exception {
+    // Given - Create a real test user
+    UserDto testUser = userService.create(
+        new UserCreateRequest("testuser", "test@example.com", "Password123!"),
+        Optional.empty()
+    );
+
+    DiscodeitUserDetails userDetails = new DiscodeitUserDetails(testUser, "password");
+
+    // Create test notifications for this user
+    notificationService.create(Set.of(testUser.id()), "New Message", "You have a new message");
+    notificationService.create(Set.of(testUser.id()), "Role Updated", "USER -> ADMIN");
+
+    // When & Then
+    mockMvc.perform(get("/api/notifications")
+            .with(user(userDetails))
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(2)));
+  }
+
+  @Test
+  @DisplayName("빈 알림 목록 조회 API 통합 테스트")
+  void findAllByReceiverId_EmptyList_IntegrationTest() throws Exception {
+    // Given - Create a real test user with no notifications
+    UserDto testUser = userService.create(
+        new UserCreateRequest("emptyuser", "empty@example.com", "Password123!"),
+        Optional.empty()
+    );
+
+    DiscodeitUserDetails userDetails = new DiscodeitUserDetails(testUser, "password");
+
+    // When & Then - No notifications created for this user
+    mockMvc.perform(get("/api/notifications")
+            .with(user(userDetails))
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(0)));
+  }
+
+  @Test
+  @DisplayName("알림 삭제 API 접근 테스트")
+  void delete_ApiAccess_IntegrationTest() throws Exception {
+    // Given - Create a real test user
+    UserDto testUser = userService.create(
+        new UserCreateRequest("deleteuser", "delete@example.com", "Password123!"),
+        Optional.empty()
+    );
+
+    DiscodeitUserDetails userDetails = new DiscodeitUserDetails(testUser, "password");
+    UUID randomNotificationId = UUID.randomUUID();
+
+    // When & Then - Test that the endpoint is accessible (will return 404 for random ID)
+    mockMvc.perform(delete("/api/notifications/{notificationId}", randomNotificationId)
+            .with(user(userDetails))
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 알림 삭제 API 통합 테스트")
+  void delete_NotFound_IntegrationTest() throws Exception {
+    // Given - Create a real test user
+    UserDto testUser = userService.create(
+        new UserCreateRequest("notfounduser", "notfound@example.com", "Password123!"),
+        Optional.empty()
+    );
+
+    DiscodeitUserDetails userDetails = new DiscodeitUserDetails(testUser, "password");
+    UUID nonExistentNotificationId = UUID.randomUUID();
+
+    // When & Then
+    mockMvc.perform(delete("/api/notifications/{notificationId}", nonExistentNotificationId)
+            .with(user(userDetails))
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("인증되지 않은 사용자의 알림 조회 요청")
+  void findAllByReceiverId_Unauthorized() throws Exception {
+    // When & Then - Spring Security returns 403 Forbidden for unauthorized requests
+    mockMvc.perform(get("/api/notifications")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("인증되지 않은 사용자의 알림 삭제 요청")
+  void delete_Unauthorized() throws Exception {
+    // Given
+    UUID notificationId = UUID.randomUUID();
+
+    // When & Then - Spring Security returns 403 Forbidden for unauthorized requests
+    mockMvc.perform(delete("/api/notifications/{notificationId}", notificationId)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("다중 수신자 알림 생성 통합 테스트")
+  void multipleReceivers_NotificationCreation() throws Exception {
+    // Given - Create test users
+    UserDto testUser1 = userService.create(
+        new UserCreateRequest("multi1", "multi1@example.com", "Password123!"),
+        Optional.empty()
+    );
+
+    UserDto testUser2 = userService.create(
+        new UserCreateRequest("multi2", "multi2@example.com", "Password123!"),
+        Optional.empty()
+    );
+
+    DiscodeitUserDetails userDetails1 = new DiscodeitUserDetails(testUser1, "password");
+
+    // When - Create notification for multiple users
+    notificationService.create(Set.of(testUser1.id(), testUser2.id()), "Broadcast Message",
+        "This message goes to multiple users");
+
+    // Then - Test that first user can see their notification
+    mockMvc.perform(get("/api/notifications")
+            .with(user(userDetails1))
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(1)));
+  }
+
+  @Test
+  @DisplayName("API 기본 접근 테스트")
+  void basicApiAccess() throws Exception {
+    // Given - Create a test user for authentication
+    UserDto testUser = userService.create(
+        new UserCreateRequest("apiuser", "api@example.com", "Password123!"),
+        Optional.empty()
+    );
+
+    DiscodeitUserDetails userDetails = new DiscodeitUserDetails(testUser, "password");
+
+    // When & Then - Simply test that the API is accessible
+    mockMvc.perform(get("/api/notifications")
+            .with(user(userDetails))
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray());
+  }
+}

--- a/src/test/java/com/sprint/mission/discodeit/security/CsrfTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/security/CsrfTest.java
@@ -1,0 +1,34 @@
+package com.sprint.mission.discodeit.security;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+public class CsrfTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("CSRF 토큰 요청 테스트")
+  void getCsrfToken() throws Exception {
+    // When & Then - CSRF 토큰 엔드포인트가 정상적으로 호출되는지만 확인
+    mockMvc.perform(get("/api/auth/csrf-token"))
+        .andExpect(status().isNoContent())
+        .andExpect(cookie().exists("XSRF-TOKEN"))
+    ;
+  }
+}

--- a/src/test/java/com/sprint/mission/discodeit/security/LoginTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/security/LoginTest.java
@@ -1,0 +1,138 @@
+package com.sprint.mission.discodeit.security;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sprint.mission.discodeit.dto.data.UserDto;
+import com.sprint.mission.discodeit.dto.request.LoginRequest;
+import com.sprint.mission.discodeit.entity.Role;
+import com.sprint.mission.discodeit.exception.user.UserNotFoundException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.MultiValueMap;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+public class LoginTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private PasswordEncoder passwordEncoder;
+  @MockitoBean
+  private UserDetailsService userDetailsService;
+
+  @Test
+  @DisplayName("로그인 성공 테스트")
+  void login_Success() throws Exception {
+    // Given
+    LoginRequest loginRequest = new LoginRequest(
+        "testuser",
+        "Password1!"
+    );
+
+    UUID userId = UUID.randomUUID();
+    UserDto loggedInUser = new UserDto(
+        userId,
+        "testuser",
+        "test@example.com",
+        null,
+        false,
+        Role.USER
+    );
+
+    given(userDetailsService.loadUserByUsername(any(String.class)))
+        .willReturn(new DiscodeitUserDetails(loggedInUser, passwordEncoder.encode("Password1!")));
+
+    // When & Then
+    mockMvc.perform(post("/api/auth/login")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .formFields(MultiValueMap.fromMultiValue(Map.of(
+                "username", List.of(loginRequest.username()),
+                "password", List.of(loginRequest.password())
+            ))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userDto.id").value(userId.toString()))
+        .andExpect(jsonPath("$.userDto.username").value("testuser"))
+        .andExpect(jsonPath("$.userDto.email").value("test@example.com"))
+        .andExpect(jsonPath("$.userDto.online").value(false))
+        .andExpect(jsonPath("$.accessToken").exists());
+  }
+
+  @Test
+  @DisplayName("로그인 실패 테스트 - 존재하지 않는 사용자")
+  void login_Failure_UserNotFound() throws Exception {
+    // Given
+
+    LoginRequest loginRequest = new LoginRequest(
+        "nonexistentuser",
+        "Password1!"
+    );
+
+    given(userDetailsService.loadUserByUsername(any(String.class)))
+        .willThrow(UserNotFoundException.withUsername(loginRequest.username()));
+
+    // When & Then
+    mockMvc.perform(post("/api/auth/login")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .formFields(MultiValueMap.fromMultiValue(Map.of(
+                "username", List.of(loginRequest.username()),
+                "password", List.of(loginRequest.password())
+            ))))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("로그인 실패 테스트 - 잘못된 비밀번호")
+  void login_Failure_InvalidCredentials() throws Exception {
+    // Given
+    LoginRequest loginRequest = new LoginRequest(
+        "testuser",
+        "WrongPassword1!"
+    );
+    UUID userId = UUID.randomUUID();
+    UserDto loggedInUser = new UserDto(
+        userId,
+        "testuser",
+        "test@example.com",
+        null,
+        false,
+        Role.USER
+    );
+
+    given(userDetailsService.loadUserByUsername(any(String.class)))
+        .willReturn(new DiscodeitUserDetails(loggedInUser, passwordEncoder.encode("Password1!")));
+
+    // When & Then
+    mockMvc.perform(post("/api/auth/login")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .formFields(MultiValueMap.fromMultiValue(Map.of(
+                "username", List.of(loginRequest.username()),
+                "password", List.of(loginRequest.password())
+            ))))
+        .andExpect(status().isUnauthorized());
+  }
+
+}

--- a/src/test/java/com/sprint/mission/discodeit/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/security/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,153 @@
+package com.sprint.mission.discodeit.security.jwt;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.sprint.mission.discodeit.dto.data.UserDto;
+import com.sprint.mission.discodeit.entity.Role;
+import com.sprint.mission.discodeit.security.DiscodeitUserDetails;
+import com.sprint.mission.discodeit.security.DiscodeitUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+  @Mock
+  private JwtTokenProvider tokenProvider;
+
+  @Mock
+  private DiscodeitUserDetailsService userDetailsService;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  @Mock
+  private FilterChain filterChain;
+
+  @Mock
+  private SecurityContext securityContext;
+
+  @Mock
+  private PrintWriter printWriter;
+
+  @Mock
+  private JwtRegistry jwtRegistry;
+
+  private JwtAuthenticationFilter jwtAuthenticationFilter;
+  private DiscodeitUserDetails userDetails;
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+
+    jwtAuthenticationFilter = new JwtAuthenticationFilter(tokenProvider, userDetailsService,
+        objectMapper, jwtRegistry);
+
+    UUID userId = UUID.randomUUID();
+    UserDto userDto = new UserDto(
+        userId,
+        "testuser",
+        "test@example.com",
+        null,
+        false,
+        Role.USER
+    );
+
+    userDetails = new DiscodeitUserDetails(userDto, "encoded-password");
+
+    SecurityContextHolder.setContext(securityContext);
+  }
+
+  @Test
+  @DisplayName("JWT 인증 필터 - 유효한 토큰으로 인증 성공")
+  void doFilterInternal_ValidToken_SetsAuthentication() throws Exception {
+    // Given
+    String token = "valid.jwt.token";
+    String username = "testuser";
+
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+    given(tokenProvider.validateAccessToken(token)).willReturn(true);
+    given(tokenProvider.getUsernameFromToken(token)).willReturn(username);
+    given(userDetailsService.loadUserByUsername(username)).willReturn(userDetails);
+    given(jwtRegistry.hasActiveJwtInformationByAccessToken(token)).willReturn(true);
+
+    // When
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // Then
+    verify(securityContext).setAuthentication(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  @DisplayName("JWT 인증 필터 - 토큰 없음, 인증 설정하지 않음")
+  void doFilterInternal_NoToken_DoesNotSetAuthentication() throws Exception {
+    // Given
+    when(request.getHeader("Authorization")).thenReturn(null);
+
+    // When
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // Then
+    verify(securityContext, never()).setAuthentication(any());
+    verify(tokenProvider, never()).validateAccessToken(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  @DisplayName("JWT 인증 필터 - 잘못된 토큰, 인증 설정하지 않음")
+  void doFilterInternal_InvalidToken_DoesNotSetAuthentication() throws Exception {
+    // Given
+    String token = "invalid.jwt.token";
+
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+    given(tokenProvider.validateAccessToken(token)).willReturn(false);
+    when(response.getWriter()).thenReturn(printWriter);
+
+    // When
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // Then
+    verify(securityContext, never()).setAuthentication(any());
+    verify(userDetailsService, never()).loadUserByUsername(any());
+    verify(filterChain, never()).doFilter(request, response);
+    verify(response).setStatus(401);
+  }
+
+  @Test
+  @DisplayName("JWT 인증 필터 - Bearer 없는 Authorization 헤더, 인증 설정하지 않음")
+  void doFilterInternal_NonBearerToken_DoesNotSetAuthentication() throws Exception {
+    // Given
+    when(request.getHeader("Authorization")).thenReturn("Basic dGVzdDp0ZXN0");
+
+    // When
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // Then
+    verify(securityContext, never()).setAuthentication(any());
+    verify(tokenProvider, never()).validateAccessToken(any());
+    verify(filterChain).doFilter(request, response);
+  }
+}

--- a/src/test/java/com/sprint/mission/discodeit/security/jwt/JwtLoginSuccessHandlerTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/security/jwt/JwtLoginSuccessHandlerTest.java
@@ -1,0 +1,130 @@
+package com.sprint.mission.discodeit.security.jwt;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.nimbusds.jose.JOSEException;
+import com.sprint.mission.discodeit.dto.data.UserDto;
+import com.sprint.mission.discodeit.entity.Role;
+import com.sprint.mission.discodeit.security.DiscodeitUserDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class JwtLoginSuccessHandlerTest {
+
+  @Mock
+  private JwtTokenProvider tokenProvider;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  @Mock
+  private Authentication authentication;
+
+  @Mock
+  private JwtRegistry jwtRegistry;
+
+  private JwtLoginSuccessHandler jwtLoginSuccessHandler;
+  private ObjectMapper objectMapper;
+  private DiscodeitUserDetails userDetails;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    jwtLoginSuccessHandler = new JwtLoginSuccessHandler(objectMapper, tokenProvider, jwtRegistry);
+
+    UUID userId = UUID.randomUUID();
+    UserDto userDto = new UserDto(
+        userId,
+        "testuser",
+        "test@example.com",
+        null,
+        false,
+        Role.USER
+    );
+
+    userDetails = new DiscodeitUserDetails(userDto, "encoded-password");
+  }
+
+  @Test
+  @DisplayName("JWT 로그인 성공 핸들러 - 성공 테스트")
+  void onAuthenticationSuccess_Success() throws Exception {
+    // Given
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+
+    when(response.getWriter()).thenReturn(printWriter);
+    when(authentication.getPrincipal()).thenReturn(userDetails);
+    given(tokenProvider.generateAccessToken(any(DiscodeitUserDetails.class)))
+        .willReturn("test.jwt.token");
+
+    // When
+    jwtLoginSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+    // Then
+    verify(response).setCharacterEncoding("UTF-8");
+    verify(response).setContentType(MediaType.APPLICATION_JSON_VALUE);
+    verify(response).setStatus(HttpServletResponse.SC_OK);
+    verify(tokenProvider).generateAccessToken(userDetails);
+
+    String responseBody = stringWriter.toString();
+    assert responseBody.contains("\"accessToken\":\"test.jwt.token\"");
+    assert responseBody.contains("\"username\":\"testuser\"");
+  }
+
+  @Test
+  @DisplayName("JWT 로그인 성공 핸들러 - 토큰 생성 실패 테스트")
+  void onAuthenticationSuccess_TokenGenerationFailure() throws Exception {
+    // Given
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+
+    when(response.getWriter()).thenReturn(printWriter);
+    when(authentication.getPrincipal()).thenReturn(userDetails);
+    given(tokenProvider.generateAccessToken(any(DiscodeitUserDetails.class)))
+        .willThrow(new JOSEException("Token generation failed"));
+
+    // When
+    jwtLoginSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+    // Then
+    verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  @DisplayName("JWT 로그인 성공 핸들러 - 잘못된 사용자 정보 테스트")
+  void onAuthenticationSuccess_InvalidUserDetails() throws Exception {
+    // Given
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+
+    when(response.getWriter()).thenReturn(printWriter);
+    when(authentication.getPrincipal()).thenReturn("invalid-user-details");
+
+    // When
+    jwtLoginSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+    // Then
+    verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+  }
+}

--- a/src/test/java/com/sprint/mission/discodeit/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/security/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,208 @@
+package com.sprint.mission.discodeit.security.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nimbusds.jose.JOSEException;
+import com.sprint.mission.discodeit.dto.data.UserDto;
+import com.sprint.mission.discodeit.entity.Role;
+import com.sprint.mission.discodeit.security.DiscodeitUserDetails;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JwtTokenProviderTest {
+
+  private JwtTokenProvider jwtTokenProvider;
+  private DiscodeitUserDetails userDetails;
+
+  @BeforeEach
+  void setUp() throws JOSEException {
+    String testAccessSecret = "test-access-secret-key-for-jwt-token-generation-and-validation-must-be-long-enough";
+    String testRefreshSecret = "test-refresh-secret-key-for-jwt-token-generation-and-validation-must-be-long-enough";
+    int testAccessExpirationMs = 1800000; // 30 minutes
+    int testRefreshExpirationMs = 604800000; // 7 days
+
+    jwtTokenProvider = new JwtTokenProvider(testAccessSecret, testAccessExpirationMs,
+        testRefreshSecret, testRefreshExpirationMs);
+
+    UUID userId = UUID.randomUUID();
+    UserDto userDto = new UserDto(
+        userId,
+        "testuser",
+        "test@example.com",
+        null,
+        false,
+        Role.USER
+    );
+
+    userDetails = new DiscodeitUserDetails(userDto, "encoded-password");
+  }
+
+  @Test
+  @DisplayName("JWT 토큰 생성 테스트")
+  void generateAccessToken_Success() throws JOSEException {
+    // When
+    String token = jwtTokenProvider.generateAccessToken(userDetails);
+
+    // Then
+    assertThat(token).isNotNull();
+    assertThat(token).isNotEmpty();
+    assertThat(token.split("\\.")).hasSize(3); // JWT should have 3 parts: header.payload.signature
+  }
+
+  @Test
+  @DisplayName("유효한 JWT 토큰 검증 테스트")
+  void validateToken_ValidAccessToken_ReturnsTrue() throws JOSEException {
+    // Given
+    String token = jwtTokenProvider.generateAccessToken(userDetails);
+
+    // When
+    boolean isValid = jwtTokenProvider.validateAccessToken(token);
+
+    // Then
+    assertThat(isValid).isTrue();
+  }
+
+  @Test
+  @DisplayName("잘못된 JWT 토큰 검증 테스트")
+  void validateToken_InvalidAccessToken_ReturnsFalse() {
+    // Given
+    String invalidToken = "invalid.jwt.token";
+
+    // When
+    boolean isValid = jwtTokenProvider.validateAccessToken(invalidToken);
+
+    // Then
+    assertThat(isValid).isFalse();
+  }
+
+  @Test
+  @DisplayName("null 토큰 검증 테스트")
+  void validateToken_NullAccessToken_ReturnsFalse() {
+    // When
+    boolean isValid = jwtTokenProvider.validateAccessToken(null);
+
+    // Then
+    assertThat(isValid).isFalse();
+  }
+
+  @Test
+  @DisplayName("빈 토큰 검증 테스트")
+  void validateToken_EmptyAccessToken_ReturnsFalse() {
+    // When
+    boolean isValid = jwtTokenProvider.validateAccessToken("");
+
+    // Then
+    assertThat(isValid).isFalse();
+  }
+
+  @Test
+  @DisplayName("JWT 토큰에서 사용자명 추출 테스트")
+  void getUsernameFromToken_ValidToken_ReturnsUsername() throws JOSEException {
+    // Given
+    String token = jwtTokenProvider.generateAccessToken(userDetails);
+
+    // When
+    String username = jwtTokenProvider.getUsernameFromToken(token);
+
+    // Then
+    assertThat(username).isEqualTo("testuser");
+  }
+
+  @Test
+  @DisplayName("잘못된 토큰에서 사용자명 추출 테스트 - 예외 발생")
+  void getUsernameFromToken_InvalidToken_ThrowsException() {
+    // Given
+    String invalidToken = "invalid.jwt.token";
+
+    // When & Then
+    assertThatThrownBy(() -> jwtTokenProvider.getUsernameFromToken(invalidToken))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid JWT token");
+  }
+
+  @Test
+  @DisplayName("JWT 토큰에서 토큰 ID 추출 테스트")
+  void getTokenId_ValidToken_ReturnsTokenId() throws JOSEException {
+    // Given
+    String token = jwtTokenProvider.generateAccessToken(userDetails);
+
+    // When
+    String tokenId = jwtTokenProvider.getTokenId(token);
+
+    // Then
+    assertThat(tokenId).isNotNull();
+    assertThat(tokenId).isNotEmpty();
+    // UUID format check
+    assertThat(UUID.fromString(tokenId)).isNotNull();
+  }
+
+  @Test
+  @DisplayName("잘못된 토큰에서 토큰 ID 추출 테스트 - 예외 발생")
+  void getTokenId_InvalidToken_ThrowsException() {
+    // Given
+    String invalidToken = "invalid.jwt.token";
+
+    // When & Then
+    assertThatThrownBy(() -> jwtTokenProvider.getTokenId(invalidToken))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid JWT token");
+  }
+
+  @Test
+  @DisplayName("만료된 토큰 검증 테스트")
+  void validateToken_ExpiredAccessToken_ReturnsFalse() throws JOSEException {
+    // Given - Create provider with very short expiration (1ms)
+    JwtTokenProvider shortExpirationProvider = new JwtTokenProvider(
+        "test-access-secret-key-for-jwt-token-generation-and-validation-must-be-long-enough",
+        1,
+        "test-refresh-secret-key-for-jwt-token-generation-and-validation-must-be-long-enough",
+        604800000
+    );
+
+    String token = shortExpirationProvider.generateAccessToken(userDetails);
+
+    // Wait for token to expire
+    try {
+      Thread.sleep(10);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
+    // When
+    boolean isValid = shortExpirationProvider.validateAccessToken(token);
+
+    // Then
+    assertThat(isValid).isFalse();
+  }
+
+  @Test
+  @DisplayName("다른 사용자의 토큰 생성 및 검증 테스트")
+  void generateAccessToken_DifferentUser_HasDifferentClaims() throws JOSEException {
+    // Given
+    UUID anotherUserId = UUID.randomUUID();
+    UserDto anotherUserDto = new UserDto(
+        anotherUserId,
+        "anotheruser",
+        "another@example.com",
+        null,
+        true,
+        Role.ADMIN
+    );
+    DiscodeitUserDetails anotherUserDetails = new DiscodeitUserDetails(anotherUserDto,
+        "another-password");
+
+    // When
+    String token1 = jwtTokenProvider.generateAccessToken(userDetails);
+    String token2 = jwtTokenProvider.generateAccessToken(anotherUserDetails);
+
+    // Then
+    assertThat(token1).isNotEqualTo(token2);
+    assertThat(jwtTokenProvider.getUsernameFromToken(token1)).isEqualTo("testuser");
+    assertThat(jwtTokenProvider.getUsernameFromToken(token2)).isEqualTo("anotheruser");
+    assertThat(jwtTokenProvider.getTokenId(token1)).isNotEqualTo(
+        jwtTokenProvider.getTokenId(token2));
+  }
+}

--- a/src/test/java/com/sprint/mission/discodeit/service/basic/BasicNotificationServiceTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/service/basic/BasicNotificationServiceTest.java
@@ -1,0 +1,197 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.sprint.mission.discodeit.dto.data.NotificationDto;
+import com.sprint.mission.discodeit.entity.Notification;
+import com.sprint.mission.discodeit.exception.notification.NotificationNotFoundException;
+import com.sprint.mission.discodeit.mapper.NotificationMapper;
+import com.sprint.mission.discodeit.repository.NotificationRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BasicNotificationServiceTest {
+
+  @Mock
+  private NotificationRepository notificationRepository;
+
+  @Mock
+  private NotificationMapper notificationMapper;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+
+  @InjectMocks
+  private BasicNotificationService notificationService;
+
+  private UUID receiverId;
+  private UUID notificationId;
+  private Notification notification;
+  private NotificationDto notificationDto;
+
+  @BeforeEach
+  void setUp() {
+    receiverId = UUID.randomUUID();
+    notificationId = UUID.randomUUID();
+    
+    notification = new Notification(receiverId, "Test Title", "Test Content");
+    ReflectionTestUtils.setField(notification, "id", notificationId);
+    
+    notificationDto = new NotificationDto(
+        notificationId,
+        Instant.now(),
+        receiverId,
+        "Test Title",
+        "Test Content"
+    );
+  }
+
+  @Test
+  @DisplayName("수신자별 알림 목록 조회 성공")
+  void findAllByReceiverId_Success() {
+    // given
+    List<Notification> notifications = List.of(notification);
+    given(notificationRepository.findAllByReceiverIdOrderByCreatedAtDesc(receiverId))
+        .willReturn(notifications);
+    given(notificationMapper.toDto(notification)).willReturn(notificationDto);
+
+    // when
+    List<NotificationDto> result = notificationService.findAllByReceiverId(receiverId);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0)).isEqualTo(notificationDto);
+    verify(notificationRepository).findAllByReceiverIdOrderByCreatedAtDesc(receiverId);
+    verify(notificationMapper).toDto(notification);
+  }
+
+  @Test
+  @DisplayName("수신자별 알림 목록 조회 - 빈 목록")
+  void findAllByReceiverId_EmptyList() {
+    // given
+    given(notificationRepository.findAllByReceiverIdOrderByCreatedAtDesc(receiverId))
+        .willReturn(List.of());
+
+    // when
+    List<NotificationDto> result = notificationService.findAllByReceiverId(receiverId);
+
+    // then
+    assertThat(result).isEmpty();
+    verify(notificationRepository).findAllByReceiverIdOrderByCreatedAtDesc(receiverId);
+    verifyNoInteractions(notificationMapper);
+  }
+
+  @Test
+  @DisplayName("알림 삭제 성공")
+  void delete_Success() {
+    // given
+    given(notificationRepository.findById(notificationId))
+        .willReturn(Optional.of(notification));
+
+    // when
+    notificationService.delete(notificationId, receiverId);
+
+    // then
+    verify(notificationRepository).findById(notificationId);
+    verify(notificationRepository).delete(notification);
+  }
+
+  @Test
+  @DisplayName("알림 삭제 실패 - 존재하지 않는 알림")
+  void delete_Failure_NotificationNotFound() {
+    // given
+    given(notificationRepository.findById(notificationId))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> notificationService.delete(notificationId, receiverId))
+        .isInstanceOf(NotificationNotFoundException.class);
+    
+    verify(notificationRepository).findById(notificationId);
+    verify(notificationRepository, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("다중 수신자 알림 생성 성공")
+  void create_MultipleReceivers_Success() {
+    // given
+    UUID receiverId1 = UUID.randomUUID();
+    UUID receiverId2 = UUID.randomUUID();
+    Set<UUID> receiverIds = Set.of(receiverId1, receiverId2);
+    String title = "Test Title";
+    String content = "Test Content";
+
+    // when
+    notificationService.create(receiverIds, title, content);
+
+    // then
+    verify(notificationRepository).saveAll(anyList());
+  }
+
+  @Test
+  @DisplayName("빈 수신자 집합으로 알림 생성 시 아무 동작 안함")
+  void create_EmptyReceiverSet_NoAction() {
+    // given
+    Set<UUID> emptyReceiverIds = Set.of();
+    String title = "Test Title";
+    String content = "Test Content";
+
+    // when
+    notificationService.create(emptyReceiverIds, title, content);
+
+    // then
+    verifyNoInteractions(notificationRepository);
+  }
+
+  @Test
+  @DisplayName("단일 수신자 알림 생성 성공")
+  void create_SingleReceiver_Success() {
+    // given
+    Set<UUID> receiverIds = Set.of(receiverId);
+    String title = "Test Title";
+    String content = "Test Content";
+
+    // when
+    notificationService.create(receiverIds, title, content);
+
+    // then
+    verify(notificationRepository).saveAll(anyList());
+  }
+
+  @Test
+  @DisplayName("알림 생성 시 올바른 Notification 객체 생성")
+  void create_CreatesCorrectNotificationObjects() {
+    // given
+    UUID receiverId1 = UUID.randomUUID();
+    UUID receiverId2 = UUID.randomUUID();
+    Set<UUID> receiverIds = Set.of(receiverId1, receiverId2);
+    String title = "Role Updated";
+    String content = "USER -> ADMIN";
+
+    // when
+    notificationService.create(receiverIds, title, content);
+
+    // then
+    verify(notificationRepository).saveAll(any(List.class));
+  }
+}


### PR DESCRIPTION
## 요구사항

### 기본
#### Spring Event - 파일 업로드 로직 분리하기
- 디스코드잇은 BinaryContent의 메타 데이터(DB)와 바이너리 데이터(FileSystem/S3)를 분리해 저장합니다.

- 만약 지금처럼 두 로직이 하나의 트랜잭션으로 묶인 경우 트랜잭션을 과도하게 오래 점유할 수 있는 문제가 있습니다.
  - 바이너리 데이터 저장 연산은 오래 걸릴 수 있는 연산이며, 해당 연산이 끝날 때까지 트랜잭션이 대기해야합니다.

- 따라서 Spring Event를 활용해 메타 데이터 저장 트랜잭션으로부터 바이너리 데이터 저장 로직을 분리하여, 메타데이터 저장 트랜잭션이 종료되면 바이너리 데이터를 저장하도록 변경합니다.

- [x]  BinaryContentStorage.put을 직접 호출하는 대신 BinaryContentCreatedEvent를 발행하세요.
  - BinaryContentCreatedEvent를 정의하세요.

- BinaryContent 메타 정보가 DB에 잘 저장되었다는 사실을 의미하는 이벤트입니다.
  - 다음의 메소드에서 BinaryContentStorage를 호출하는 대신 BinaryContentCreatedEvent를 발행하세요.
    - UserService.create/update
    - MessageService.create
    - BinaryContentService.create
  - ApplicationEventPublisher를 활용하세요.

- [x]  이벤트를 받아 실제 바이너리 데이터를 저장하는 리스너를 구현하세요.
  - 이벤트를 발행한 메인 서비스의 트랜잭션이 커밋되었을 때 리스너가 실행되도록 설정하세요.
  - BinaryContentStorage를 통해 바이너리 데이터를 저장하세요.
- [x]  바이너리 데이터 저장 성공 여부를 알 수 있도록 메타 데이터를 리팩토링하세요.

<img width="786" height="1064" alt="11-1" src="https://github.com/user-attachments/assets/cb6f44d6-28aa-4dda-9cf8-e782944a1b08" />

  - BinaryContent에 바이너리 데이터 업로드 상태 속성(status)을 추가하세요.

<img width="641" height="357" alt="11-2" src="https://github.com/user-attachments/assets/9eb1113f-f29d-421d-bcc5-ed75f099e557" />

- PROCESSING: 업로드 중
  - 기본값입니다.
- SUCCESS: 업로드 완료
- FAIL: 업로드 실패

<pre>
-- schema.sql
CREATE TABLE binary_contents
(
    id           uuid PRIMARY KEY,
    created_at   timestamp with time zone NOT NULL,
    updated_at timestamp with time zone,
    file_name    varchar(255)             NOT NULL,
    size         bigint                   NOT NULL,
    content_type varchar(100)             NOT NULL,
    status       varchar(20)              NOT NULL
);

-- ALTER TABLE binary_contents
--      ADD COLUMN updated_at timestamp with time zone;
-- ALTER TABLE binary_contents
--      ADD COLUMN status varchar(20) NOT NULL;
</pre>


  - BinaryContent의 상태를 업데이트하는 메소드를 정의하세요.

<img width="674" height="161" alt="11-3" src="https://github.com/user-attachments/assets/8552f747-e644-4bf8-83ac-144186615cda" />

    - 트랜잭션 전파 범위에 유의하세요.

- [x]  바이너리 데이터 저장 성공 여부를 메타 데이터에 반영하세요.
  - 성공 시 BinaryContent의 status를 SUCCESS로 업데이트하세요.
  - 실패 시 BinaryContent의 status를 FAIL로 업데이트하세요.

#### Spring Event - 알림 기능 추가하기
- 1)채널에 새로운 메시지가 등록되거나 2)권한이 변경된 경우 이벤트를 발행해 알림을 받을 수 있도록 구현합니다.

- [x] 채널에 새로운 메시지가 등록된 경우 알림을 받을 수 있도록 리팩토링하세요.
  - MessageCreatedEvent를 정의하고 새로운 메시지가 등록되면 이벤트를 발행하세요.
  - 사용자 별로 관심있는 채널의 알림만 받을 수 있도록 ReadStatus 엔티티에 채널 알림 여부 속성(notificationEnabled)을 추가하세요.
<img width="312" height="184" alt="11-4" src="https://github.com/user-attachments/assets/43376399-3b4a-4742-b802-33c0e92522c5" />
 
   - PRIVATE 채널은 알림 여부를 true로 초기화합니다.
   - PUBLIC 채널은 알림 여부를 false로 초기화합니다.

<pre>
-- schema.sql
CREATE TABLE read_statuses
(
    id           uuid PRIMARY KEY,
    created_at   timestamp with time zone NOT NULL,
    updated_at   timestamp with time zone,
    user_id      uuid                     NOT NULL,
    channel_id   uuid                     NOT NULL,
    last_read_at timestamp with time zone NOT NULL,
    notification_enabled boolean NOT NULL,
    UNIQUE (user_id, channel_id)
);

-- ALTER TABLE read_statuses
--      ADD COLUMN notification_enabled boolean NOT NULL;
</pre>

- 알림 여부를 수정할 수 있게 ReadStatusUpdateRequest를 수정하세요.
<img width="345" height="184" alt="11-5" src="https://github.com/user-attachments/assets/4b02e984-d47d-44d7-aa82-766141babc29" />

  - 알림이 활성화 되어 있는 경우
<img width="276" height="92" alt="image" src="https://github.com/user-attachments/assets/d04ecc91-ecea-4f5d-8a2c-7e23b7e7b7fc" />

  - 알림이 활성화 되어 있지 않은 경우
<img width="238" height="82" alt="image" src="https://github.com/user-attachments/assets/76744994-bbb7-43fd-873e-44e5266153cb" />

- [x] 사용자의 권한(Role)이 변경된 경우 알림을 받을 수 있도록 리팩토링하세요.
  - RoleUpdatedEvent를 정의하고 권한이 변경되면 이벤트를 발행하세요.
- [x] 알림 API를 구현하세요.
  - NotificationDto를 정의하세요.
<img width="235" height="253" alt="image" src="https://github.com/user-attachments/assets/1aa63e4d-ae76-4775-8a1b-1138fa1273bd" />

- receiverId: 알림을 수신할 User의 id입니다.

- 알림 조회
  - 엔드포인트: GET /api/notifications
  - 요청
    - 헤더: 엑세스 토큰
  - 응답
    - 200 List<NotifcationDto>
    - 401 ErrorResponse

- 알림 확인
  - 엔드포인트: DELETE /api/notifications/{notificationId}
  - 요청
    - 헤더: 엑세스 토큰
  - 응답
    - 204 Void
    - 인증되지 않은 요청: 401 ErrorResponse
    - 인가되지 않은 요청: 403 ErrorResponse
      - 요청자 본인의 알림에 대해서만 수행할 수 있습니다.
    - 알림이 없는 경우: 404 ErrorResponse

- [x] 알림이 필요한 이벤트가 발행되었을 때 알림을 생성하세요.
  - 이벤트를 처리할 리스너를 구현하세요.
<pre>
public class NotificationRequiredEventListener {

  @TransactionalEventListener
  public void on(MessageCreatedEvent event) {...}

  @TransactionalEventListener
  public void on(RoleUpdatedEvent event) {...}
}
</pre>

- on(MessageCreatedEvent)
  - 해당 채널의 알림 여부를 활성화한 ReadStatus를 조회합니다.
  - 해당 ReadStatus의 사용자들에게 알림을 생성합니다.
<pre>
# 알림 예시
title: "보낸 사람 (#채널명)"
content: "메시지 내용"
</pre>
<img width="572" height="250" alt="image" src="https://github.com/user-attachments/assets/e59c9bc2-3420-4596-aa9e-b1e46c7d90a8" />
  
- 단, 해당 메시지를 보낸 사람은 알림 대상에서 제외합니다.

- on(RoleUpdatedEvent)
  - 권한이 변경된 당사자에게 알림을 생성합니다.
<pre>
# 알림 예시
title: "권한이 변경되었습니다."
content: "USER -> CHANNEL_MANAGER"
</pre>
<img width="538" height="248" alt="image" src="https://github.com/user-attachments/assets/471dd7e9-39d4-4885-ac58-029e0934501d" />

#### 비동기 적용하기
- [ ] 비동기를 적용하기 위한 설정(AsyncConfig) 클래스를 구현하세요.
  - @EanbleAsync 어노테이션을 활용하세요.
  - TaskExecutor를 Bean으로 등록하세요.
  - TaskDecorator를 활용해 MDC의 Request ID, SecurityContext의 인정 정보가 비동기 스레드에서도 유지되도록 구현하세요.
- [ ] 앞서 구현한 Event Listener를 비동기적으로 처리하세요.
  - [ ] @Async 어노테이션을 활용하세요.
- [ ] 동기 처리와 비동기 처리 간 성능 차이를 비교해보세요.
  - 파일 업로드 로직에 의도적인 지연(Thread.sleep(…))을 발생시키세요.
<pre>
// LocalBinaryContentStorage
public UUID put(UUID binaryContentId, byte[] bytes) {
    try {
      Thread.sleep(3000);
    } catch (InterruptedException e) {
      Thread.currentThread().interrupt();
      throw new RuntimeException("Thread interrupted while simulating delay", e);
    }
    ...
}
</pre>

- 메시지 생성 API의 실행 시간을 측정해보세요.
  - @Timed 어노테이션을 메소드에 추가합니다.
<pre>
// MessageController
  @Timed("message.create.async")
  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
  public ResponseEntity<MessageDto> create(...) {...}
</pre>

  - Actuator 설정을 추가합니다.
<pre>
# application.yaml
management:
    ...
  observations:
    annotations:
      enabled: true
</pre>
  - /actuator/metrics/message.create.async 에서 측정된 시간을 확인할 수 있습니다.
- @EnableAsync를 활성화 / 비활성화 해보면서 동기 / 비동기 처리 간 응답 속도의 차이를 확인해보세요.

#### 비동기 실패 처리하기
- 비동기로 처리하는 로직이 실패하는 경우 사용자에게 즉각적인 에러 전파가 되지 않을 가능성이 높습니다.
- 따라서 비동기로 처리하는 로직은 자동 재시도 전략을 통해 더 견고하게 구현해야 합니다.
- 또, 실패하더라도 그 사실을 명확하게 기록해두어야 에러에 대응할 수 있습니다.
- [ ] S3를 활용해 바이너리 데이터 저장 시 자동 재시도 매커니즘을 구축하세요.
  - Spring Retry를 위한 환경을 구성하세요.
    - org.springframework.retry:spring-retry 의존성을 추가하세요.
    - @EnableRetry 어노테이션을 활용해 Spring Retry를 활성화 하세요.
  - 바이너리 데이터를 저장하는 메소드에 @Retryable 어노테이션을 사용해 재시도 정책(횟수, 대기 시간 등)을 설정하세요.

- [ ] 재시도가 모두 실패했을 때 대응 전략을 구축하세요.
  - @Recover 어노테이션을 활용하세요.
  - 실패 정보를 관리자에게 통지하세요.

<img width="694" height="278" alt="image" src="https://github.com/user-attachments/assets/623e83de-6919-4cd6-b09b-0c7eeb977ad8" />

<pre>
# 알림 내용 예시
RequestId: 7641467e369e458a98033558a83321fb
BinaryContentId: b0549c2a-014c-4761-8b21-4b77d3bd011c
Error: The AWS Access Key Id you provided does not exist in our records. (Service: S3, Status Code: 403, Request ID: B7KCVSRCGPYJZREX, Extended Request ID: AWRVuJJJ3upwwOkCnd+yhHkgSajUxdg7L4195lbMVTIka6WnBpjZLLRTReoHbgIMf9zzH/QQM0Y5ZOVJCHF2F+l2mSyPG/+8Ee2XBS8hcqk=) (SDK Attempt Count: 1)
</pre>

- 실패 정보에는 추후 디버깅을 위해 필요한 정보를 포함하세요.
  - 실패한 작업 이름
  - MDC의 Request ID
  - 실패 이유 (예외 메시지)

#### 캐시 적용하기
- [ ] Caffeine 캐시를 위한 환경을 구성하세요.
  - org.springframework.boot:spring-boot-starter-cache 의존성을 추가하세요.
  - com.github.ben-manes.caffeine:caffeine 의존성을 추가하세요.
  - application.yaml 설정 또는 Bean을 통해 캐시 Caffeine 캐시를 설정하세요.

- [ ] @Cacheable 어노테이션을 활용해 캐시가 필요한 메소드에 적용하세요.
  - 사용자별 채널 목록 조회
  - 사용자별 알림 목록 조회
  - 사용자 목록 조회


- [ ] 데이터 변경 시, 캐시를 갱신 또는 무효화하는 로직을 구현하세요.
  - @CacheEvict, @CachePut, CacheManager 등을 활용하세요.
  - 예시:
    - 새로운 채널 추가/수정/삭제 → 채널 목록 캐시 무효화
    - 알림 추가/삭제 → 알림 목록 캐시 무효화
    - 사용자 추가/로그인/로그아웃 → 사용자 목록 캐시 무효화

- [ ] 캐시 적용 전후의 차이를 비교해보세요.
  - 로그를 통해 SQL 실행 여부를 확인해보세요.
- [ ] Spring Actuator를 활용해 캐시 관련 통계 지표를 확인해보세요.
  - Caffein Spec에 recordStats 옵션을 추가하세요.

<pre>
  # application.yaml
  cache:
        ...
    caffeine:
      spec: >
        maximumSize=100,
        expireAfterAccess=600s,
        recordStats
</pre>

  -/actuator/caches, /actuator/metrics/cache.* 를 통해 캐시 관련 데이터를 확인해보세요.

#### 유의사항
- 이번 실습은 분산 환경을 대비한 기술 도입을 목표로 합니다. 특히, 여러 서버나 인스턴스로 구성되는 시스템에서 발생할 수 있는 문제를 해결하는 데 필요한 기술을 학습합니다.
  - Kafka를 통한 이벤트 발행/구독
  - Redis를 활용한 전역 캐시 저장소 구성
- 이번 미션에서는 Kafka, Redis의 세부 설정이나 고급 기능보다는, 기술을 간단하게 적용하고, 분산 환경의 필요성과 기존 시스템의 한계를 이해하는 데 집중해주세요.

## 멘토에게
- 늦게 제출해서 죄송합니다! 
